### PR TITLE
windows: add file suffix for cmd, bat

### DIFF
--- a/src/ipc/background.ts
+++ b/src/ipc/background.ts
@@ -183,7 +183,7 @@ ipcMain.handle(Background.SHOW_SELECT_USI_ENGINE_DIALOG, (): string => {
   const results = dialog.showOpenDialogSync(win, {
     properties: ["openFile", "noResolveAliases"],
     filters: isWindows
-      ? [{ name: "実行可能ファイル", extensions: ["exe"] }]
+      ? [{ name: "実行可能ファイル", extensions: ["exe", "cmd", "bat"] }]
       : undefined,
   });
   return results && results.length === 1 ? results[0] : "";


### PR DESCRIPTION
例えば、以下のような手順で導入できる [WebAssembly版やねうら王（現在はテスト版）](https://github.com/mizar/YaneuraOu.wasm)のような、`cmd`,`bat`拡張子から起動できるUSIエンジンをファイル一覧から選択できるようにします。

> 1. Node.js をインストール
> https://nodejs.org/ja/
> 
> 2. Windows+R キー操作 「ファイル名を指定して実行」 欄に以下を入力して実行
> ```
> npm -g i @mizarjp/yaneuraou.k-p@latest @mizarjp/yaneuraou.material@latest @mizarjp/yaneuraou.material9@latest @mizarjp/yaneuraou.komoringheights-mate@latest
> ```
> 
> 3. 実行ファイルをGUIに登録
> 
> SuishoPetit（k-p:軽量版NNUE）の場合
> 
> - 将棋所: メニューバーより「対局(G)」→「エンジン管理...」→「追加...」→ファイル名入力欄に `"%APPDATA%\npm\usi.k-p.cmd"` と入力して「開く(O)」
> - ShogiGUI: メニューバーより「ツール(T)」→「エンジン設定(E)」→「追加」→ファイル名入力欄に `"%APPDATA%\npm\usi.k-p.cmd"` と入力して「開く(O)」
> 
> 以下、同様に
> 
> - SuishoPetit（k-p:軽量版NNUE）:
> ```
> "%APPDATA%\npm\usi.k-p.cmd"
> ```
> - MaterialLv1（静的評価関数Lv1: 駒得のみ）:
> ```
> "%APPDATA%\npm\usi.material.cmd"
> ```
> - MaterialLv9（静的評価関数Lv9）:
> ```
> "%APPDATA%\npm\usi.material9.cmd"
> ```
> - [KomoringHeights-mate（詰将棋エンジン）](https://github.com/komori-n/KomoringHeights):
> ```
> "%APPDATA%\npm\usi.komoringheights-mate.cmd"
> ```
