### PR TITLE
fix promotion UI layout #71

### DIFF
--- a/src/components/primitive/BoardLayout.ts
+++ b/src/components/primitive/BoardLayout.ts
@@ -611,7 +611,8 @@ export default class LayoutBuilder {
       const x =
         boardLayout.x +
         (layoutTemplate.board.leftSquarePadding +
-          layoutTemplate.board.squreWidth * (square.x - 0.5)) *
+          layoutTemplate.board.squreWidth *
+            (square.x === 0 ? 0 : square.x === 8 ? 7 : square.x - 0.5)) *
           ratio;
       const y =
         boardLayout.y +


### PR DESCRIPTION
https://github.com/sunfish-shogi/electron-shogi/issues/71

1 筋や 9 筋で成・不成の選択を出す際に、盤からはみ出さないように修正します。

![スクリーンショット (26)](https://user-images.githubusercontent.com/6257462/166744862-da6ea1c2-7144-42ed-8e25-91ae41f12807.png)

![スクリーンショット (28)](https://user-images.githubusercontent.com/6257462/166744857-99343b66-8894-4bcd-8ac1-912beb6c80ec.png)