### PR TITLE
Update pv preview

### DIFF
--- a/src/components/dialog/PVPreviewDialog.vue
+++ b/src/components/dialog/PVPreviewDialog.vue
@@ -2,6 +2,7 @@
   <div>
     <dialog ref="dialog">
       <BoardView
+        class="board"
         :piece-image-type="appSetting.pieceImage"
         :board-image-type="appSetting.boardImage"
         :board-label-type="appSetting.boardLabelType"
@@ -39,6 +40,11 @@
           </div>
         </template>
       </BoardView>
+      <div class="informations">
+        <div v-for="info in infos" :key="info" class="information">
+          {{ info }}
+        </div>
+      </div>
     </dialog>
   </div>
 </template>
@@ -75,6 +81,11 @@ export default defineComponent({
       type: Object as PropType<string[]>,
       required: true,
     },
+    infos: {
+      type: Object as PropType<string[]>,
+      default: [] as string[],
+      required: false,
+    },
   },
   emits: ["close"],
   setup(props, context) {
@@ -86,7 +97,7 @@ export default defineComponent({
 
     const updateSize = () => {
       maxSize.width = window.innerWidth * 0.8;
-      maxSize.height = window.innerHeight * 0.8;
+      maxSize.height = window.innerHeight * 0.8 - 80;
     };
 
     const updateRecord = () => {
@@ -170,6 +181,10 @@ export default defineComponent({
 </script>
 
 <style scoped>
+.board {
+  margin-left: auto;
+  margin-right: auto;
+}
 .control {
   width: 100%;
   height: 100%;
@@ -198,5 +213,19 @@ export default defineComponent({
   height: 80%;
   width: auto;
   vertical-align: top;
+}
+.informations {
+  height: 80px;
+  width: 80vw;
+  overflow-y: scroll;
+  margin-left: auto;
+  margin-right: auto;
+  color: var(--text-color);
+  background-color: var(--text-bg-color);
+}
+.information {
+  font-size: 14px;
+  margin: 2px;
+  text-align: left;
 }
 </style>

--- a/src/components/tab/EngineAnalyticsElement.vue
+++ b/src/components/tab/EngineAnalyticsElement.vue
@@ -71,9 +71,10 @@
         </div>
       </div>
       <PVPreviewDialog
-        v-if="preview && preview.pv"
+        v-if="preview"
         :position="preview.position"
         :pv="preview.pv"
+        :infos="preview.infos"
         @close="closePreview"
       />
     </div>
@@ -86,6 +87,12 @@ import { defineComponent, ref } from "vue";
 import { Icon } from "@/assets/icons";
 import ButtonIcon from "@/components/primitive/ButtonIcon.vue";
 import PVPreviewDialog from "@/components/dialog/PVPreviewDialog.vue";
+
+type Preview = {
+  position: string;
+  pv: string[];
+  infos: string[];
+};
 
 export default defineComponent({
   name: "EngineAnalyticsElement",
@@ -108,9 +115,35 @@ export default defineComponent({
     },
   },
   setup: () => {
-    const preview = ref<USIIteration | null>(null);
+    const preview = ref<Preview | null>(null);
     const showPreview = (ite: USIIteration) => {
-      preview.value = ite;
+      const infos = [];
+      if (ite.depth !== undefined) {
+        infos.push(`深さ=${ite.depth}`);
+      }
+      if (ite.selectiveDepth !== undefined) {
+        infos.push(`選択的深さ=${ite.selectiveDepth}`);
+      }
+      if (ite.score) {
+        infos.push(`評価値=${ite.score}`);
+        if (ite.lowerBound) {
+          infos.push("（下界値）");
+        }
+        if (ite.upperBound) {
+          infos.push("（上界値）");
+        }
+      }
+      if (ite.scoreMate) {
+        infos.push(`詰み手数=${ite.scoreMate}`);
+      }
+      if (ite.multiPV) {
+        infos.push(`順位=${ite.multiPV}`);
+      }
+      preview.value = {
+        position: ite.position,
+        pv: ite.pv || [],
+        infos: [infos.join(" / "), ite.text || ""],
+      };
     };
     const closePreview = () => {
       preview.value = null;


### PR DESCRIPTION
https://github.com/sunfish-shogi/electron-shogi/pull/139 で、読み筋をオーバーレイで盤面表示できる機能を実装した。
しかし、「思考」タブの情報と重なってしまい、かつ思考中の場合はタブ内の情報がどんどん更新されてしまうので、評価値や深さの情報がいくつだったかは画面上でわからなくなってしまう。
そこで、オーバーレイ表示した盤面の下部にテキストベースの読み筋や評価値、探索深さ等の情報を表示する。

![スクリーンショット (53)](https://user-images.githubusercontent.com/6257462/173366471-df90ab79-5f13-4431-b8f5-58ba930db0bc.png)

