### PR TITLE
Change sfen behavior not to append "sfen" prefix

### DIFF
--- a/src/shogi/position.ts
+++ b/src/shogi/position.ts
@@ -77,7 +77,7 @@ export interface ImmutablePosition {
   isValidMove(move: Move): boolean;
   isValidEditing(from: Square | Piece, to: Square | Color): boolean;
   readonly sfen: string;
-  getSfen(nextMoveNumber: number): string;
+  getSFEN(nextMoveNumber: number): string;
   clone(): Position;
 }
 
@@ -415,11 +415,11 @@ export default class Position {
   }
 
   get sfen(): string {
-    return this.getSfen(1);
+    return this.getSFEN(1);
   }
 
-  getSfen(nextMoveNumber: number): string {
-    let ret = `sfen ${this._board.sfen} ${colorToSFEN(this.color)} `;
+  getSFEN(nextMoveNumber: number): string {
+    let ret = `${this._board.sfen} ${colorToSFEN(this.color)} `;
     ret += Hand.formatSFEN(this._blackHand, this._whiteHand);
     ret += " " + nextMoveNumber;
     return ret;

--- a/src/shogi/record.ts
+++ b/src/shogi/record.ts
@@ -598,7 +598,7 @@ export default class Record {
   }
 
   get usi(): string {
-    let ret = "position " + this.initialPosition.sfen + " moves";
+    let ret = "position sfen " + this.initialPosition.sfen + " moves";
     this.movesBefore.forEach((node) => {
       if (node.move instanceof Move) {
         ret += " " + node.move.sfen;
@@ -621,7 +621,7 @@ export default class Record {
   }
 
   get sfen(): string {
-    return this.position.getSfen(this._current.number + 1);
+    return this.position.getSFEN(this._current.number + 1);
   }
 
   forEach(handler: (node: Node) => void): void {

--- a/tests/unit/shogi/csa.spec.ts
+++ b/tests/unit/shogi/csa.spec.ts
@@ -52,7 +52,7 @@ T40
       record.metadata.getStandardMetadata(RecordMetadataKey.WHITE_NAME)
     ).toBe("Mr.Vue");
     expect(record.initialPosition.sfen).toBe(
-      "sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1"
+      "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1"
     );
     expect(record.current.number).toBe(0);
     expect(record.current.move).toBe(SpecialMove.START);
@@ -107,7 +107,7 @@ P-00AL
     const record = importCSA(data) as Record;
     expect(record).toBeInstanceOf(Record);
     expect(record.initialPosition.sfen).toBe(
-      "sfen 7n1/6gk1/6gpN/9/9/6b1P/9/9/9 b 2R2Gb4s2n4l16p 1"
+      "7n1/6gk1/6gpN/9/9/6b1P/9/9/9 b 2R2Gb4s2n4l16p 1"
     );
     expect(record.current.number).toBe(0);
     expect(record.current.move).toBe(SpecialMove.START);
@@ -495,12 +495,12 @@ T16
       record.metadata.getStandardMetadata(RecordMetadataKey.WHITE_NAME)
     ).toBe("dlshogi with HEROZ");
     expect(record.initialPosition.sfen).toBe(
-      "sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1"
+      "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1"
     );
     record.goto(177);
     expect(record.current.move).toBe(SpecialMove.RESIGN);
     expect(record.position.sfen).toBe(
-      "sfen k1gl4l/9/3+P2+Rp1/p1p2N2p/1P1pG4/PNPg1P1PP/K1L1P4/2B2+n3/LNrP1b3 b S4Pg3s 1"
+      "k1gl4l/9/3+P2+Rp1/p1p2N2p/1P1pG4/PNPg1P1PP/K1L1P4/2B2+n3/LNrP1b3 b S4Pg3s 1"
     );
   });
 
@@ -512,7 +512,7 @@ PI82HI
     const record = importCSA(data) as Record;
     expect(record).toBeInstanceOf(Record);
     expect(record.initialPosition.sfen).toBe(
-      "sfen lnsgkgsnl/7b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 1"
+      "lnsgkgsnl/7b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 1"
     );
   });
 
@@ -580,7 +580,7 @@ T56
 
   it("export/custom-position", () => {
     const position = Position.newBySFEN(
-      "sfen 7n1/6gk1/6gpN/9/9/6b1P/9/9/9 b 2R2Gb4s2n4l16p 1"
+      "7n1/6gk1/6gpN/9/9/6b1P/9/9/9 b 2R2Gb4s2n4l16p 1"
     ) as Position;
     const record = new Record(position) as Record;
     const move = (ff: number, fr: number, tf: number, tr: number): Move => {

--- a/tests/unit/shogi/kakinoki.spec.ts
+++ b/tests/unit/shogi/kakinoki.spec.ts
@@ -126,7 +126,7 @@ describe("shogi/kakinoki", () => {
     record.goto(64);
     expect(record.current.comment).toBe("4六桂の方が良かった。");
     expect(record.sfen).toBe(
-      "sfen l+B5nl/4g1gk1/2b1p2p1/p1p2pp2/3s1P2p/P1P3PP1/1P2PSN1P/2G2GK2/L7L b RSNPrsn2p 65"
+      "l+B5nl/4g1gk1/2b1p2p1/p1p2pp2/3s1P2p/P1P3PP1/1P2PSN1P/2G2GK2/L7L b RSNPrsn2p 65"
     );
     record.goto(999);
     expect(record.current.number).toBe(94);
@@ -656,7 +656,7 @@ describe("shogi/kakinoki", () => {
     expect(record.current.move).toBe(SpecialMove.RESIGN);
     expect(record.current.comment).toBe("");
     expect(record.sfen).toBe(
-      "sfen lnkg2b+Rl/6r2/p2p1G2p/5pp2/1SpNp2NP/1P1P1PP2/P1G1P4/4G4/L2KB3L w S4P2sn 115"
+      "lnkg2b+Rl/6r2/p2p1G2p/5pp2/1SpNp2NP/1P1P1PP2/P1G1P4/4G4/L2KB3L w S4P2sn 115"
     );
   });
 });

--- a/tests/unit/shogi/position.spec.ts
+++ b/tests/unit/shogi/position.spec.ts
@@ -29,53 +29,51 @@ describe("shogi/position", () => {
   it("reset", () => {
     const position = new Position();
     position.reset(InitialPositionType.EMPTY);
-    expect(position.sfen).toBe("sfen 9/9/9/9/9/9/9/9/9 b - 1");
+    expect(position.sfen).toBe("9/9/9/9/9/9/9/9/9 b - 1");
     position.reset(InitialPositionType.STANDARD);
     expect(position.sfen).toBe(
-      "sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1"
+      "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1"
     );
     position.reset(InitialPositionType.HANDICAP_LANCE);
     expect(position.sfen).toBe(
-      "sfen lnsgkgsn1/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 1"
+      "lnsgkgsn1/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 1"
     );
     position.reset(InitialPositionType.HANDICAP_RIGHT_LANCE);
     expect(position.sfen).toBe(
-      "sfen 1nsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 1"
+      "1nsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 1"
     );
     position.reset(InitialPositionType.HANDICAP_BISHOP);
     expect(position.sfen).toBe(
-      "sfen lnsgkgsnl/1r7/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 1"
+      "lnsgkgsnl/1r7/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 1"
     );
     position.reset(InitialPositionType.HANDICAP_ROOK);
     expect(position.sfen).toBe(
-      "sfen lnsgkgsnl/7b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 1"
+      "lnsgkgsnl/7b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 1"
     );
     position.reset(InitialPositionType.HANDICAP_ROOK_LANCE);
     expect(position.sfen).toBe(
-      "sfen lnsgkgsn1/7b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 1"
+      "lnsgkgsn1/7b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 1"
     );
     position.reset(InitialPositionType.HANDICAP_2PIECES);
     expect(position.sfen).toBe(
-      "sfen lnsgkgsnl/9/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 1"
+      "lnsgkgsnl/9/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 1"
     );
     position.reset(InitialPositionType.HANDICAP_4PIECES);
     expect(position.sfen).toBe(
-      "sfen 1nsgkgsn1/9/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 1"
+      "1nsgkgsn1/9/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 1"
     );
     position.reset(InitialPositionType.HANDICAP_6PIECES);
     expect(position.sfen).toBe(
-      "sfen 2sgkgs2/9/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 1"
+      "2sgkgs2/9/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 1"
     );
     position.reset(InitialPositionType.HANDICAP_8PIECES);
     expect(position.sfen).toBe(
-      "sfen 3gkg3/9/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 1"
+      "3gkg3/9/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 1"
     );
     position.reset(InitialPositionType.TSUME_SHOGI);
-    expect(position.sfen).toBe("sfen 4k4/9/9/9/9/9/9/9/9 b 2r2b4g4s4n4l18p 1");
+    expect(position.sfen).toBe("4k4/9/9/9/9/9/9/9/9 b 2r2b4g4s4n4l18p 1");
     position.reset(InitialPositionType.TSUME_SHOGI_2KINGS);
-    expect(position.sfen).toBe(
-      "sfen 4k4/9/9/9/9/9/9/9/4K4 b 2r2b4g4s4n4l18p 1"
-    );
+    expect(position.sfen).toBe("4k4/9/9/9/9/9/9/9/4K4 b 2r2b4g4s4n4l18p 1");
   });
 
   it("doMove", () => {
@@ -396,7 +394,7 @@ describe("shogi/position", () => {
 
   it("sfen", () => {
     const sfen =
-      "sfen l2R2s1+P/4gg1k1/p1+P2lPp1/4p1p+b1/1p3G3/3pP1nS1/PP3KSP1/R8/L4G2+b b NL4Ps2np 1";
+      "l2R2s1+P/4gg1k1/p1+P2lPp1/4p1p+b1/1p3G3/3pP1nS1/PP3KSP1/R8/L4G2+b b NL4Ps2np 1";
     const position = Position.newBySFEN(sfen);
     expect(position).toBeInstanceOf(Position);
     expect(position?.color).toBe(Color.BLACK);


### PR DESCRIPTION
関連: https://github.com/sunfish-shogi/electron-shogi/issues/17

Position クラスで sfen 形式の局面表記を生成した際に `sfen ` というプレフィクスを付与していたのをやめる。

