### PR TITLE
Add new board solid.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "electron-shogi",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "electron-shogi",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/public/board/solid.svg
+++ b/public/board/solid.svg
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   id="svg4755"
+   width="1100"
+   height="1200"
+   viewBox="0 0 1100 1200"
+   sodipodi:docname="solid.svg"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
+   inkscape:export-filename="C:\Users\danle\OneDrive\Pictures\Chess Variants\Shogi\Boards\Square\solid-natural.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <metadata
+     id="metadata4761">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4759" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1368"
+     inkscape:window-height="888"
+     id="namedview4757"
+     showgrid="false"
+     inkscape:zoom="0.1705172"
+     inkscape:cx="211.1224"
+     inkscape:cy="639.2317"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g4763"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     width="1023px"
+     showborder="false"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <g
+     inkscape:groupmode="layer"
+     inkscape:label="Image"
+     id="g4763"
+     transform="translate(0,1016.0247)">
+    <g
+       id="g1436"
+       transform="matrix(134.19819,0,0,146.6758,14.862167,-1000.9191)"
+       inkscape:export-xdpi="96"
+       inkscape:export-ydpi="96"
+       style="stroke-width:0.89106">
+      <rect
+         style="opacity:1;fill:#f4bf57;fill-opacity:1;stroke:#ffeeaa;stroke-width:0.00987539;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+         id="rect5591"
+         width="7.959166"
+         height="7.959166"
+         x="0.008085317"
+         y="0.0080860928"
+         inkscape:export-xdpi="96"
+         inkscape:export-ydpi="96" />
+      <circle
+         cx="2.6610737"
+         cy="2.6610754"
+         id="circle843"
+         style="stroke-width:0.0140918"
+         inkscape:export-xdpi="96"
+         inkscape:export-ydpi="96"
+         r="0.058410641" />
+      <circle
+         cx="2.6632164"
+         cy="5.3162737"
+         id="circle845"
+         style="stroke-width:0.0146278"
+         inkscape:export-xdpi="96"
+         inkscape:export-ydpi="96"
+         r="0.058410641" />
+      <circle
+         cx="5.3140879"
+         cy="2.6610324"
+         id="circle847"
+         style="stroke-width:0.0140815"
+         inkscape:export-xdpi="96"
+         inkscape:export-ydpi="96"
+         r="0.058410641" />
+      <circle
+         id="circle849"
+         style="stroke-width:0.0140918"
+         cy="5.3141308"
+         cx="5.3141308"
+         inkscape:export-xdpi="96"
+         inkscape:export-ydpi="96"
+         r="0.058410641" />
+      <path
+         d="M 0.00808453,0.00808443 V 7.9672521 m 0.884352,-7.95916767 V 7.9672521 M 1.77679,0.00808443 V 7.9672521 M 2.66114,0.00808443 V 7.9672521 M 3.545492,0.00808443 c 0,2.83988917 0.0019,5.31054137 0,7.95916767 M 4.429842,0.00808443 V 7.9672521 M 5.314196,0.00808443 V 7.9672521 M 6.198547,0.00808443 V 7.9672521 M 7.082899,0.00808443 V 7.9672521 M 7.967252,0.00808443 V 7.9672521 M 0.00808453,0.00808443 H 7.967252 M 0.00808453,0.89243725 H 7.967252 M 0.00808453,1.7767887 H 7.967252 m -7.95916747,0.884353 c 2.69444147,-0.00828 5.31104947,-9.852e-4 7.95916747,0 M 0.00808453,3.545493 H 7.967252 M 0.00808453,4.4298434 H 7.967252 M 0.00808453,5.3141964 H 7.967252 M 0.00808453,6.1985476 H 7.967252 M 0.00808453,7.0829 H 7.967252 M 0.00808453,7.9672521 H 7.967252"
+         style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.0141076px"
+         id="path22173"
+         sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccc"
+         inkscape:export-xdpi="96"
+         inkscape:export-ydpi="96" />
+    </g>
+  </g>
+</svg>

--- a/src/components/dialog/AppSettingDialog.vue
+++ b/src/components/dialog/AppSettingDialog.vue
@@ -356,6 +356,10 @@ export default defineComponent({
         name: "ダーク",
         value: BoardImageType.DARK,
       },
+      {
+        name: "ソイド",
+        value: BoardImageType.SOLID,
+      },
     ];
 
     return {

--- a/src/components/primitive/BoardLayout.ts
+++ b/src/components/primitive/BoardLayout.ts
@@ -24,6 +24,7 @@ export enum BoardImageType {
   WARM = "warm",
   RESIN = "resin",
   DARK = "dark",
+  SOLID = "solid"
 }
 
 export enum BoardLabelType {
@@ -321,6 +322,7 @@ const boardImageMap = {
   [BoardImageType.WARM]: "./board/warm.png",
   [BoardImageType.RESIN]: "./board/resin.png",
   [BoardImageType.DARK]: "./board/dark.png",
+  [BoardImageType.SOLID]: "./board/solid.svg",
 };
 
 const handColorMap = {
@@ -328,6 +330,7 @@ const handColorMap = {
   [BoardImageType.WARM]: "#8b4513",
   [BoardImageType.RESIN]: "#8b4513",
   [BoardImageType.DARK]: "#333333",
+  [BoardImageType.SOLID]: "8b4513",
 };
 
 const handLaytoutRule = {


### PR DESCRIPTION
This PR try adds a new board solid.

The new board is taken from Lishogi (Licensed by AGPL) and modified to match the layout of Electron Shogi.

![image](https://user-images.githubusercontent.com/9823531/181743519-799a8fb4-86b2-4e59-b345-9ebb0b44e42e.png)

# Why

Because all four boards now we have are blurred under HIDPI... This new board is SVG and will not have the same problem.
