### PR TITLE
Disable scrollbar of body element

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -129,6 +129,9 @@ body {
   font-size: 17px;
   margin: 0;
 }
+body::-webkit-scrollbar {
+  display: none;
+}
 #app {
   text-align: center;
   height: 100vh;


### PR DESCRIPTION
ダイアログを表示した際、ページ全体に対してスクロールバーが一瞬表示されて消えたり、あるいはそのまま表示され続ける事がある。
そこで、 CSS によって強制的にスクロールバーを無効化する。

![scrollbar-issue](https://user-images.githubusercontent.com/6257462/185420199-8e555569-a5cb-4808-b472-38c53a0b7519.png)
