### PR TITLE
Add removeNextMove

### DIFF
--- a/src/components/main/BoardPane.vue
+++ b/src/components/main/BoardPane.vue
@@ -139,8 +139,8 @@
           </button>
           <button
             class="control-item"
-            :disabled="!controlStates.removeAfter"
-            @click="onRemoveAfter"
+            :disabled="!controlStates.removeCurrentMove"
+            @click="onRemoveCurrentMove"
           >
             <ButtonIcon class="icon" :icon="Icon.DELETE" />
             指し手削除
@@ -277,8 +277,8 @@ export default defineComponent({
       isFileMenuVisible.value = true;
     };
 
-    const onRemoveAfter = () => {
-      store.removeRecordAfter();
+    const onRemoveCurrentMove = () => {
+      store.removeCurrentMove();
     };
 
     const allowEdit = computed(
@@ -345,7 +345,7 @@ export default defineComponent({
         startEditPosition: store.appState === AppState.NORMAL,
         endEditPosition: store.appState === AppState.POSITION_EDITING,
         initPosition: store.appState === AppState.POSITION_EDITING,
-        removeAfter:
+        removeCurrentMove:
           store.appState === AppState.NORMAL ||
           store.appState === AppState.RESEARCH,
         engineSettings: store.appState === AppState.NORMAL,
@@ -382,7 +382,7 @@ export default defineComponent({
       onOpenEngineSettings,
       onFlip,
       onFileAction,
-      onRemoveAfter,
+      onRemoveCurrentMove,
       allowEdit,
       allowMove,
       Icon,

--- a/src/ipc/background/menu.ts
+++ b/src/ipc/background/menu.ts
@@ -161,7 +161,7 @@ const menuTemplate: Array<MenuItemConstructorOptions | MenuItem> = [
       },
       menuItem(
         "現在の位置から棋譜を削除",
-        MenuEvent.REMOVE_RECORD_AFTER,
+        MenuEvent.REMOVE_CURRENT_MOVE,
         [AppState.NORMAL, AppState.RESEARCH],
         "CmdOrCtrl+D"
       ),

--- a/src/ipc/menu.ts
+++ b/src/ipc/menu.ts
@@ -20,7 +20,7 @@ export enum MenuEvent {
   INSERT_ENTERING_OF_KING = "insertEnteringOfKing",
   INSERT_WIN_BY_DEFAULT = "insertWinByDefault",
   INSERT_LOSS_BY_DEFAULT = "insertLossByDefault",
-  REMOVE_RECORD_AFTER = "remvoeRecordAfter",
+  REMOVE_CURRENT_MOVE = "remvoeCurrentMove",
   START_POSITION_EDITING = "startPositionEditing",
   END_POSITION_EDITING = "endPositionEditing",
   CHANGE_TURN = "changeTurn",

--- a/src/ipc/setup.ts
+++ b/src/ipc/setup.ts
@@ -90,8 +90,8 @@ export function setup(): void {
       case MenuEvent.INSERT_LOSS_BY_DEFAULT:
         store.insertSpecialMove(SpecialMove.LOSS_BY_DEFAULT);
         break;
-      case MenuEvent.REMOVE_RECORD_AFTER:
-        store.removeRecordAfter();
+      case MenuEvent.REMOVE_CURRENT_MOVE:
+        store.removeCurrentMove();
         break;
       case MenuEvent.START_POSITION_EDITING:
         store.startPositionEditing();

--- a/src/shogi/record.ts
+++ b/src/shogi/record.ts
@@ -561,7 +561,7 @@ export default class Record {
     return true;
   }
 
-  removeAfter(): void {
+  removeCurrentMove(): void {
     const target = this._current;
     if (!this.goBack()) {
       this._current.next = null;
@@ -586,6 +586,10 @@ export default class Record {
       this._current.next.activeBranch = true;
     }
     this.onChangePosition();
+  }
+
+  removeNextMove(): void {
+    this._current.next = null;
   }
 
   private incrementRepetition(): void {

--- a/src/store/game.ts
+++ b/src/store/game.ts
@@ -98,8 +98,11 @@ export class GameManager {
     this.repeat++;
     if (this.setting.startPosition) {
       this.recordManager.reset(this.setting.startPosition);
-    } else {
+    } else if (
+      this.recordManager.record.current.number !== this.startMoveNumber
+    ) {
       this.recordManager.changeMoveNumber(this.startMoveNumber);
+      this.recordManager.removeNextMove();
     }
     this.recordManager.setGameStartMetadata({
       gameTitle:

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -759,7 +759,7 @@ export class Store {
     }
   }
 
-  removeRecordAfter(): void {
+  removeCurrentMove(): void {
     if (
       this.appState !== AppState.NORMAL &&
       this.appState !== AppState.RESEARCH
@@ -767,13 +767,13 @@ export class Store {
       return;
     }
     if (this.recordManager.record.current.isLastMove) {
-      this.recordManager.removeAfter();
+      this.recordManager.removeCurrentMove();
       return;
     }
     this.showConfirmation({
       message: `${this.recordManager.record.current.number}手目以降を削除します。よろしいですか？`,
       onOk: () => {
-        this.recordManager.removeAfter();
+        this.recordManager.removeCurrentMove();
       },
     });
   }

--- a/src/store/record.ts
+++ b/src/store/record.ts
@@ -277,8 +277,12 @@ export class RecordManager {
     return this._record.switchBranchByIndex(index);
   }
 
-  removeAfter(): void {
-    this._record.removeAfter();
+  removeCurrentMove(): void {
+    this._record.removeCurrentMove();
+  }
+
+  removeNextMove(): void {
+    this._record.removeNextMove();
   }
 
   updateComment(comment: string): void {

--- a/tests/unit/store/index.spec.ts
+++ b/tests/unit/store/index.spec.ts
@@ -498,24 +498,24 @@ describe("store/index", () => {
       .invoke();
   });
 
-  it("removeRecordAfter", () => {
+  it("removeCurrentMove", () => {
     const store = new Store();
     store.pasteRecord(sampleBranchKIF);
     store.changeMoveNumber(8);
-    store.removeRecordAfter();
+    store.removeCurrentMove();
     expect(store.confirmation).toBeUndefined();
     expect(store.record.current.number).toBe(7);
     expect(store.record.moves.length).toBe(8);
-    store.removeRecordAfter();
+    store.removeCurrentMove();
     expect(store.confirmation).toBeUndefined();
     expect(store.record.current.number).toBe(6);
     expect(store.record.moves.length).toBe(8);
-    store.removeRecordAfter();
+    store.removeCurrentMove();
     expect(store.confirmation).toBe("6手目以降を削除します。よろしいですか？");
     store.confirmationCancel();
     expect(store.record.current.number).toBe(6);
     expect(store.record.moves.length).toBe(8);
-    store.removeRecordAfter();
+    store.removeCurrentMove();
     expect(store.confirmation).toBe("6手目以降を削除します。よろしいですか？");
     store.confirmationOk();
     expect(store.record.current.number).toBe(5);


### PR DESCRIPTION
removeNextMove を新規に作成して、 https://github.com/sunfish-shogi/electron-shogi/issues/217 の問題の修正に使用する。
また、 removeAfter は removeCurrentMove に名前を変更する。