### PR TITLE
日本語環境以外での日付表記の修正

### DIFF
--- a/src/helpers/datetime.ts
+++ b/src/helpers/datetime.ts
@@ -1,5 +1,5 @@
 export function getDateString(date?: Date): string {
-  return (date || new Date()).toLocaleDateString(undefined, {
+  return (date || new Date()).toLocaleDateString("ja-JP", {
     year: "numeric",
     month: "2-digit",
     day: "2-digit",
@@ -7,7 +7,7 @@ export function getDateString(date?: Date): string {
 }
 
 export function getDateTimeString(date?: Date): string {
-  return (date || new Date()).toLocaleTimeString(undefined, {
+  return (date || new Date()).toLocaleTimeString("ja-JP", {
     year: "numeric",
     month: "2-digit",
     day: "2-digit",

--- a/src/helpers/path.ts
+++ b/src/helpers/path.ts
@@ -1,10 +1,11 @@
 import { RecordMetadataKey } from "@/shogi";
 import { ImmutableRecordMetadata } from "@/shogi/record";
+import { getDateString } from "./datetime";
 
 export function defaultRecordFileName(
   metadata: ImmutableRecordMetadata
 ): string {
-  let ret = getDateString(metadata);
+  let ret = getDateStringByMeta(metadata);
   const title =
     metadata.getStandardMetadata(RecordMetadataKey.TITLE) ||
     metadata.getStandardMetadata(RecordMetadataKey.TOURNAMENT) ||
@@ -31,7 +32,7 @@ export function defaultRecordFileName(
   return ret.trim().replaceAll("/", "_").replaceAll("\\", "_") + ".kif";
 }
 
-function getDateString(metadata: ImmutableRecordMetadata): string {
+function getDateStringByMeta(metadata: ImmutableRecordMetadata): string {
   const date =
     metadata.getStandardMetadata(RecordMetadataKey.START_DATETIME) ||
     metadata.getStandardMetadata(RecordMetadataKey.DATE);
@@ -42,11 +43,5 @@ function getDateString(metadata: ImmutableRecordMetadata): string {
       .replaceAll("/", "")
       .replaceAll(":", "");
   }
-  return new Date()
-    .toLocaleDateString(undefined, {
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-    })
-    .replaceAll("/", "");
+  return getDateString().replaceAll("/", "");
 }

--- a/src/ipc/background/log.ts
+++ b/src/ipc/background/log.ts
@@ -2,6 +2,7 @@ import path from "path";
 import { app, shell } from "electron";
 import log4js from "log4js";
 import { loadAppSetting } from "@/ipc/background/settings";
+import { getDateTimeString } from "@/helpers/datetime";
 
 const rootDir = app.getPath("logs");
 
@@ -9,16 +10,7 @@ export function openLogsDirectory(): void {
   shell.openPath(rootDir);
 }
 
-const datetime = new Date()
-  .toLocaleTimeString(undefined, {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-    hour12: false,
-  })
+const datetime = getDateTimeString()
   .replaceAll(" ", "_")
   .replaceAll("/", "")
   .replaceAll(":", "");

--- a/tests/unit/helpers/datetime.spec.ts
+++ b/tests/unit/helpers/datetime.spec.ts
@@ -1,0 +1,13 @@
+import { getDateString, getDateTimeString } from "@/helpers/datetime";
+
+describe("helpers/datetime", () => {
+  it("getDateTimeString", async () => {
+    expect(getDateString()).toMatch(/^[0-9]{4}\/[0-9]{2}\/[0-9]{2}$/);
+  });
+
+  it("getDateTimeString", async () => {
+    expect(getDateTimeString()).toMatch(
+      /^[0-9]{4}\/[0-9]{2}\/[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$/
+    );
+  });
+});

--- a/tests/unit/helpers/path.spec.ts
+++ b/tests/unit/helpers/path.spec.ts
@@ -1,0 +1,66 @@
+import { defaultRecordFileName } from "@/helpers/path";
+import { RecordMetadata, RecordMetadataKey } from "@/shogi";
+
+describe("helpers/path", () => {
+  it("defaultRecordFileName/emptyMetadata", async () => {
+    const meta = new RecordMetadata();
+    expect(defaultRecordFileName(meta)).toMatch(/^[0-9]{8}\.kif$/);
+  });
+
+  it("defaultRecordFileName/withDate", async () => {
+    const meta = new RecordMetadata();
+    meta.setStandardMetadata(RecordMetadataKey.DATE, "2022/09/30");
+    expect(defaultRecordFileName(meta)).toBe("20220930.kif");
+  });
+
+  it("defaultRecordFileName/withStartDateTime", async () => {
+    const meta = new RecordMetadata();
+    meta.setStandardMetadata(RecordMetadataKey.DATE, "2022/01/01");
+    meta.setStandardMetadata(
+      RecordMetadataKey.START_DATETIME,
+      "2022/01/02 11:30"
+    );
+    expect(defaultRecordFileName(meta)).toBe("20220102_1130.kif");
+  });
+
+  it("defaultRecordFileName/withTitle", async () => {
+    const meta = new RecordMetadata();
+    meta.setStandardMetadata(RecordMetadataKey.DATE, "2022/01/01");
+    meta.setStandardMetadata(
+      RecordMetadataKey.START_DATETIME,
+      "2022/01/02 11:30"
+    );
+    meta.setStandardMetadata(RecordMetadataKey.TITLE, "My New Game");
+    expect(defaultRecordFileName(meta)).toBe("20220102_1130_My New Game.kif");
+  });
+
+  it("defaultRecordFileName/withTournament", async () => {
+    const meta = new RecordMetadata();
+    meta.setStandardMetadata(RecordMetadataKey.DATE, "2022/01/01");
+    meta.setStandardMetadata(
+      RecordMetadataKey.START_DATETIME,
+      "2022/01/02 11:30"
+    );
+    meta.setStandardMetadata(RecordMetadataKey.TOURNAMENT, "My Tournament");
+    expect(defaultRecordFileName(meta)).toBe("20220102_1130_My Tournament.kif");
+  });
+
+  it("defaultRecordFileName/withPlayerName", async () => {
+    const meta = new RecordMetadata();
+    meta.setStandardMetadata(RecordMetadataKey.DATE, "2022/01/01");
+    meta.setStandardMetadata(RecordMetadataKey.BLACK_NAME, "先手の人");
+    meta.setStandardMetadata(RecordMetadataKey.WHITE_NAME, "後手の人");
+    expect(defaultRecordFileName(meta)).toBe("20220101_先手の人_後手の人.kif");
+  });
+
+  it("defaultRecordFileName/withTitleAndPlayerName", async () => {
+    const meta = new RecordMetadata();
+    meta.setStandardMetadata(RecordMetadataKey.DATE, "2022/01/01");
+    meta.setStandardMetadata(RecordMetadataKey.TITLE, "My New Game");
+    meta.setStandardMetadata(RecordMetadataKey.BLACK_NAME, "先手の人");
+    meta.setStandardMetadata(RecordMetadataKey.WHITE_NAME, "後手の人");
+    expect(defaultRecordFileName(meta)).toBe(
+      "20220101_My New Game_先手の人_後手の人.kif"
+    );
+  });
+});


### PR DESCRIPTION
日本語以外の環境では Year, Month, Day の順序や、使われる記号が異なるのでロケールを明確に指定するように修正する。