### PR TITLE
Use ☗ and ☖

### DIFF
--- a/src/components/primitive/BoardView.vue
+++ b/src/components/primitive/BoardView.vue
@@ -16,7 +16,7 @@
         :class="{ active: position.color == 'black' }"
         :style="layout.blackPlayerName.style"
       >
-        <span class="player-name-text">▲{{ blackPlayerName }}</span>
+        <span class="player-name-text">☗{{ blackPlayerName }}</span>
       </div>
       <div
         class="clock"
@@ -30,7 +30,7 @@
         :class="{ active: position.color == 'white' }"
         :style="layout.whitePlayerName.style"
       >
-        <span class="player-name-text">△{{ whitePlayerName }}</span>
+        <span class="player-name-text">☖{{ whitePlayerName }}</span>
       </div>
       <div
         class="clock"

--- a/src/shogi/move.ts
+++ b/src/shogi/move.ts
@@ -47,7 +47,7 @@ export default class Move {
 
   getDisplayText(prev?: Move | null): string {
     let text = "";
-    text += this.color === Color.BLACK ? "▲" : "△";
+    text += this.color === Color.BLACK ? "☗" : "☖";
     if (prev && prev.to.equals(this.to)) {
       text += "同　";
     } else {

--- a/tests/unit/shogi/csa.spec.ts
+++ b/tests/unit/shogi/csa.spec.ts
@@ -60,22 +60,22 @@ T40
     expect(record.current.number).toBe(0);
     expect(record.current.move).toBe(SpecialMove.START);
     record.goto(1);
-    expect((record.current.move as Move).getDisplayText()).toBe("▲７六歩(77)");
+    expect((record.current.move as Move).getDisplayText()).toBe("☗７六歩(77)");
     expect(record.current.comment).toBe(
       "初手に対するコメント\n初手に対するコメント2\n* 読み筋と評価値"
     );
     record.goto(2);
-    expect((record.current.move as Move).getDisplayText()).toBe("△３四歩(33)");
+    expect((record.current.move as Move).getDisplayText()).toBe("☖３四歩(33)");
     record.goto(3);
     expect((record.current.move as Move).getDisplayText()).toBe(
-      "▲２二角成(88)"
+      "☗２二角成(88)"
     );
     expect(record.current.elapsedMs).toBe(10000);
     record.goto(4);
-    expect((record.current.move as Move).getDisplayText()).toBe("△２二銀(31)");
+    expect((record.current.move as Move).getDisplayText()).toBe("☖２二銀(31)");
     expect(record.current.elapsedMs).toBe(20000);
     record.goto(5);
-    expect((record.current.move as Move).getDisplayText()).toBe("▲４五角打");
+    expect((record.current.move as Move).getDisplayText()).toBe("☗４五角打");
     expect(record.current.elapsedMs).toBe(30000);
     record.goto(6);
     expect(record.current.move).toBe(SpecialMove.RESIGN);
@@ -237,12 +237,12 @@ P-00AL
     expect(record.current.move).toBe(SpecialMove.START);
     record.goto(1);
     expect((record.current.move as Move).getDisplayText()).toBe(
-      "▲２一桂成(13)"
+      "☗２一桂成(13)"
     );
     record.goto(10);
-    expect((record.current.move as Move).getDisplayText()).toBe("△１二玉(11)");
+    expect((record.current.move as Move).getDisplayText()).toBe("☖１二玉(11)");
     record.goto(11);
-    expect((record.current.move as Move).getDisplayText()).toBe("▲１一飛打");
+    expect((record.current.move as Move).getDisplayText()).toBe("☗１一飛打");
     record.goto(12);
     expect(record.current.move).toBe(SpecialMove.MATE);
   });

--- a/tests/unit/shogi/kakinoki.spec.ts
+++ b/tests/unit/shogi/kakinoki.spec.ts
@@ -337,7 +337,7 @@ describe("shogi/kakinoki", () => {
     );
     record.goto(104);
     const move = record.current.move as Move;
-    expect(move.getDisplayText()).toBe("▲９一角成(64)");
+    expect(move.getDisplayText()).toBe("☗９一角成(64)");
     expect(record.current.elapsedMs).toBe(21000);
     expect(record.current.totalElapsedMs).toBe(670000);
     record.goto(999);

--- a/tests/unit/store/csa.spec.ts
+++ b/tests/unit/store/csa.spec.ts
@@ -129,11 +129,11 @@ describe("store/csa", () => {
         expect(mockHandlers.onError).toBeCalledTimes(0);
         expect(recordManager.record.moves).toHaveLength(6);
         expect(recordManager.record.moves[1].comment).toBe(
-          "互角\n*評価値=82\n*読み筋=△３四歩(33)▲２六歩(27)△８四歩(83)\n"
+          "互角\n*評価値=82\n*読み筋=☖３四歩(33)☗２六歩(27)☖８四歩(83)\n"
         );
         expect(recordManager.record.moves[2].comment).toBe("");
         expect(recordManager.record.moves[3].comment).toBe(
-          "互角\n*評価値=78\n*読み筋=△８四歩(83)▲２五歩(26)△８五歩(84)\n"
+          "互角\n*評価値=78\n*読み筋=☖８四歩(83)☗２五歩(26)☖８五歩(84)\n"
         );
         expect(recordManager.record.moves[4].comment).toBe("");
         expect(recordManager.record.moves[5].move).toBe(SpecialMove.RESIGN);

--- a/tests/unit/store/game.spec.ts
+++ b/tests/unit/store/game.spec.ts
@@ -96,13 +96,13 @@ describe("store/game", () => {
           "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f"
         );
         expect(recordManager.record.moves[1].comment).toBe(
-          "互角\n*評価値=82\n*読み筋=△３四歩(33)▲２六歩(27)△８四歩(83)\n"
+          "互角\n*評価値=82\n*読み筋=☖３四歩(33)☗２六歩(27)☖８四歩(83)\n"
         );
         expect(recordManager.record.moves[2].comment).toBe(
-          "互角\n*評価値=64\n*読み筋=▲２六歩(27)△８四歩(83)\n"
+          "互角\n*評価値=64\n*読み筋=☗２六歩(27)☖８四歩(83)\n"
         );
         expect(recordManager.record.moves[3].comment).toBe(
-          "互角\n*評価値=78\n*読み筋=△８四歩(83)▲２五歩(26)△８五歩(84)\n"
+          "互角\n*評価値=78\n*読み筋=☖８四歩(83)☗２五歩(26)☖８五歩(84)\n"
         );
       })
       .invoke();

--- a/tests/unit/store/index.spec.ts
+++ b/tests/unit/store/index.spec.ts
@@ -302,7 +302,7 @@ describe("store/index", () => {
     expect(store.usiBlackPlayerMonitor?.sfen).toBe(
       "lnsgkgsnl/1r5b1/pppppp1pp/6p2/9/2P6/PP1PPPPPP/1B5R1/LNSGKGSNL b - 1"
     );
-    expect(store.usiBlackPlayerMonitor?.ponderMove).toBe("△３四歩(33)");
+    expect(store.usiBlackPlayerMonitor?.ponderMove).toBe("☖３四歩(33)");
     expect(store.usiBlackPlayerMonitor?.iterates.length).toBe(1);
     expect(store.usiBlackPlayerMonitor?.iterates[0].depth).toBe(8);
     expect(store.usiBlackPlayerMonitor?.iterates[0].score).toBe(138);


### PR DESCRIPTION
KIF 形式以外では `▲` `△` ではなく `☗` `☖` を使うように改善する。
いずれも Unicode に追加されて久しいので文字化け等は問題にならないと思われる。