### PR TITLE
Fix garbled characters #249

### DIFF
--- a/src/shogi/move.ts
+++ b/src/shogi/move.ts
@@ -45,10 +45,27 @@ export default class Move {
     );
   }
 
-  getDisplayText(prev?: Move | null): string {
+  getDisplayText(opt?: {
+    /**
+     * 前の指し手を指定します。
+     * 指定することで「同　歩」のような表記になります。
+     */
+    prev?: Move | null;
+    /**
+     * 古いファイルフォーマットでの文字化けを防ぐ場合に指定します。
+     */
+    legacy?: boolean;
+  }): string {
     let text = "";
-    text += this.color === Color.BLACK ? "☗" : "☖";
-    if (prev && prev.to.equals(this.to)) {
+    text +=
+      this.color === Color.BLACK
+        ? opt?.legacy
+          ? "▲"
+          : "☗"
+        : opt?.legacy
+        ? "△"
+        : "☖";
+    if (opt?.prev && opt?.prev.to.equals(this.to)) {
       text += "同　";
     } else {
       text += fileDisplayTexts[this.to.file - 1];

--- a/src/shogi/record.ts
+++ b/src/shogi/record.ts
@@ -224,7 +224,7 @@ class NodeImpl implements Node {
     const prev =
       this.prev && this.prev.move instanceof Move ? this.prev.move : null;
     return this.move instanceof Move
-      ? this.move.getDisplayText(prev)
+      ? this.move.getDisplayText({ prev })
       : specialMoveToDisplayString(this.move);
   }
 

--- a/src/store/record.ts
+++ b/src/store/record.ts
@@ -99,7 +99,7 @@ export function buildSearchComment(
   if (searchInfo.pv && searchInfo.pv.length !== 0) {
     comment += `${prefix}読み筋=`;
     for (const move of searchInfo.pv) {
-      comment += `${move.getDisplayText()}`;
+      comment += `${move.getDisplayText({ legacy: true })}`;
     }
     comment += "\n";
   }

--- a/src/store/usi.ts
+++ b/src/store/usi.ts
@@ -28,7 +28,7 @@ function formatPV(position: ImmutablePosition, pv: string[]): string {
     p.doMove(move, {
       ignoreValidation: true,
     });
-    result += move.getDisplayText(prev);
+    result += move.getDisplayText({ prev });
     prev = move;
   }
   return result;

--- a/tests/unit/store/csa.spec.ts
+++ b/tests/unit/store/csa.spec.ts
@@ -129,11 +129,11 @@ describe("store/csa", () => {
         expect(mockHandlers.onError).toBeCalledTimes(0);
         expect(recordManager.record.moves).toHaveLength(6);
         expect(recordManager.record.moves[1].comment).toBe(
-          "互角\n*評価値=82\n*読み筋=☖３四歩(33)☗２六歩(27)☖８四歩(83)\n"
+          "互角\n*評価値=82\n*読み筋=△３四歩(33)▲２六歩(27)△８四歩(83)\n"
         );
         expect(recordManager.record.moves[2].comment).toBe("");
         expect(recordManager.record.moves[3].comment).toBe(
-          "互角\n*評価値=78\n*読み筋=☖８四歩(83)☗２五歩(26)☖８五歩(84)\n"
+          "互角\n*評価値=78\n*読み筋=△８四歩(83)▲２五歩(26)△８五歩(84)\n"
         );
         expect(recordManager.record.moves[4].comment).toBe("");
         expect(recordManager.record.moves[5].move).toBe(SpecialMove.RESIGN);

--- a/tests/unit/store/game.spec.ts
+++ b/tests/unit/store/game.spec.ts
@@ -96,13 +96,13 @@ describe("store/game", () => {
           "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f"
         );
         expect(recordManager.record.moves[1].comment).toBe(
-          "互角\n*評価値=82\n*読み筋=☖３四歩(33)☗２六歩(27)☖８四歩(83)\n"
+          "互角\n*評価値=82\n*読み筋=△３四歩(33)▲２六歩(27)△８四歩(83)\n"
         );
         expect(recordManager.record.moves[2].comment).toBe(
-          "互角\n*評価値=64\n*読み筋=☗２六歩(27)☖８四歩(83)\n"
+          "互角\n*評価値=64\n*読み筋=▲２六歩(27)△８四歩(83)\n"
         );
         expect(recordManager.record.moves[3].comment).toBe(
-          "互角\n*評価値=78\n*読み筋=☖８四歩(83)☗２五歩(26)☖８五歩(84)\n"
+          "互角\n*評価値=78\n*読み筋=△８四歩(83)▲２五歩(26)△８五歩(84)\n"
         );
       })
       .invoke();


### PR DESCRIPTION
https://github.com/sunfish-shogi/electron-shogi/issues/249
棋譜コメントに `☗` `☖` を使ってしまうと KIF 形式で文字化けするので棋譜コメントではレガシーな表記を使用する。