### PR TITLE
Use the word `ply`.

### DIFF
--- a/src/components/main/RecordPane.vue
+++ b/src/components/main/RecordPane.vue
@@ -53,8 +53,8 @@ export default defineComponent({
   setup() {
     const store = useStore();
 
-    const goto = (number: number) => {
-      store.changeMoveNumber(number);
+    const goto = (ply: number) => {
+      store.changePly(ply);
     };
 
     const goBegin = () => {
@@ -73,8 +73,8 @@ export default defineComponent({
       goto(Number.MAX_SAFE_INTEGER);
     };
 
-    const selectMove = (number: number) => {
-      goto(number);
+    const selectMove = (ply: number) => {
+      goto(ply);
     };
 
     const selectBranch = (index: number) => {

--- a/src/components/tab/EvaluationChart.vue
+++ b/src/components/tab/EvaluationChart.vue
@@ -295,8 +295,8 @@ export default defineComponent({
       const x =
         ((event.x - chart.scales.x.left) / displayWidth) * width +
         chart.scales.x.min;
-      const number = Math.round(x);
-      store.changeMoveNumber(number);
+      const ply = Math.round(x);
+      store.changePly(ply);
     };
 
     onMounted(() => {

--- a/src/shogi/position.ts
+++ b/src/shogi/position.ts
@@ -77,7 +77,7 @@ export interface ImmutablePosition {
   isValidMove(move: Move): boolean;
   isValidEditing(from: Square | Piece, to: Square | Color): boolean;
   readonly sfen: string;
-  getSFEN(nextMoveNumber: number): string;
+  getSFEN(nextPly: number): string;
   clone(): Position;
 }
 
@@ -411,10 +411,10 @@ export class Position {
     return this.getSFEN(1);
   }
 
-  getSFEN(nextMoveNumber: number): string {
+  getSFEN(nextPly: number): string {
     let ret = `${this._board.sfen} ${colorToSFEN(this.color)} `;
     ret += Hand.formatSFEN(this._blackHand, this._whiteHand);
-    ret += " " + nextMoveNumber;
+    ret += " " + nextPly;
     return ret;
   }
 

--- a/src/store/analysis.ts
+++ b/src/store/analysis.ts
@@ -86,7 +86,7 @@ export class AnalysisManager {
       return;
     }
 
-    this.recordManager.changeMoveNumber(this.number);
+    this.recordManager.changePly(this.number);
     const record = this.recordManager.record;
     if (record.current.number !== this.number) {
       this.finish();

--- a/src/store/game.ts
+++ b/src/store/game.ts
@@ -56,7 +56,7 @@ function newGameResults(name1: string, name2: string): GameResults {
 export class GameManager {
   private state: GameState;
   private _setting: GameSetting;
-  private startMoveNumber = 0;
+  private startPly = 0;
   private repeat = 0;
   private blackPlayer?: Player;
   private whitePlayer?: Player;
@@ -92,7 +92,7 @@ export class GameManager {
     this.playerBuilder = playerBuilder;
     this.repeat = 0;
     if (!setting.startPosition) {
-      this.startMoveNumber = this.recordManager.record.current.number;
+      this.startPly = this.recordManager.record.current.number;
     }
     this.gameResults = newGameResults(setting.black.name, setting.white.name);
     await this.nextGame();
@@ -102,10 +102,8 @@ export class GameManager {
     this.repeat++;
     if (this.setting.startPosition) {
       this.recordManager.reset(this.setting.startPosition);
-    } else if (
-      this.recordManager.record.current.number !== this.startMoveNumber
-    ) {
-      this.recordManager.changeMoveNumber(this.startMoveNumber);
+    } else if (this.recordManager.record.current.number !== this.startPly) {
+      this.recordManager.changePly(this.startPly);
       this.recordManager.removeNextMove();
     }
     this.recordManager.setGameStartMetadata({

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -752,12 +752,12 @@ export class Store {
     }
   }
 
-  changeMoveNumber(number: number): void {
+  changePly(ply: number): void {
     if (
       this.appState === AppState.NORMAL ||
       this.appState === AppState.RESEARCH
     ) {
-      this.recordManager.changeMoveNumber(number);
+      this.recordManager.changePly(ply);
     }
   }
 

--- a/src/store/record.ts
+++ b/src/store/record.ts
@@ -269,8 +269,8 @@ export class RecordManager {
     this.clearRecordFilePath();
   }
 
-  changeMoveNumber(number: number): void {
-    this._record.goto(number);
+  changePly(ply: number): void {
+    this._record.goto(ply);
   }
 
   changeBranch(index: number): boolean {

--- a/src/tests/store/index.spec.ts
+++ b/src/tests/store/index.spec.ts
@@ -501,7 +501,7 @@ describe("store/index", () => {
   it("removeCurrentMove", () => {
     const store = new Store();
     store.pasteRecord(sampleBranchKIF);
-    store.changeMoveNumber(8);
+    store.changePly(8);
     store.removeCurrentMove();
     expect(store.confirmation).toBeUndefined();
     expect(store.record.current.number).toBe(7);
@@ -553,11 +553,11 @@ describe("store/index", () => {
     store.pasteRecord(sampleCSA);
     const moves = store.record.moves;
     expect(moves.length).toBe(13);
-    store.changeMoveNumber(1);
+    store.changePly(1);
     expect(store.record.current.comment).toBe("初手へのコメント\n* 30011 2b2a");
     const customData1 = store.record.current.customData as RecordCustomData;
     expect(customData1.playerSearchInfo?.score).toBe(30011);
-    store.changeMoveNumber(2);
+    store.changePly(2);
     expect(store.record.current.comment).toBe("* 30010");
     const customData2 = store.record.current.customData as RecordCustomData;
     expect(customData2.playerSearchInfo?.score).toBe(30010);


### PR DESCRIPTION
英語のチェスでは the number of one move は将棋で言うところの２手のことを指すことが一般的なので、move number という言葉の代わりに ply を使います。関連するいくつかの `number` を `ply` に変更します。