### PR TITLE
fix not to call close() #292

### DIFF
--- a/src/store/csa.ts
+++ b/src/store/csa.ts
@@ -109,7 +109,6 @@ export class CSAGameManager {
   stop(): void {
     if (this.sessionID) {
       api.csaStop(this.sessionID);
-      this.close(true);
     }
   }
 


### PR DESCRIPTION
CSA サーバーに中断要求を出したときに応答を待たずに close していたので、結果が棋譜に入らない上に自動保存が実行されていなかった。