### PR TITLE
fix layout of PlayerSelector

### DIFF
--- a/src/components/dialog/AnalysisDialog.vue
+++ b/src/components/dialog/AnalysisDialog.vue
@@ -4,17 +4,15 @@
       <div class="dialog-title">棋譜解析</div>
       <div class="dialog-form-area">
         <div>エンジン</div>
-        <div class="dialog-form-item">
-          <PlayerSelector
-            :players="engines"
-            :player-uri="engineURI"
-            :engine-settings="engineSettings.json"
-            :display-thread-state="true"
-            :display-multi-pv-state="true"
-            @update-engine-setting="onUpdatePlayerSetting"
-            @select-player="onSelectPlayer"
-          />
-        </div>
+        <PlayerSelector
+          :players="engines"
+          :player-uri="engineURI"
+          :engine-settings="engineSettings.json"
+          :display-thread-state="true"
+          :display-multi-pv-state="true"
+          @update-engine-setting="onUpdatePlayerSetting"
+          @select-player="onSelectPlayer"
+        />
       </div>
       <div class="dialog-form-area">
         <div>開始条件</div>

--- a/src/components/dialog/ResearchDialog.vue
+++ b/src/components/dialog/ResearchDialog.vue
@@ -3,17 +3,15 @@
     <dialog ref="dialog" class="root">
       <div class="dialog-title">検討</div>
       <div class="dialog-form-area">
-        <div class="dialog-form-item">
-          <PlayerSelector
-            :players="engines"
-            :player-uri="engineURI"
-            :engine-settings="engineSettings.json"
-            :display-thread-state="true"
-            :display-multi-pv-state="true"
-            @update-engine-setting="onUpdatePlayerSetting"
-            @select-player="onSelectPlayer"
-          />
-        </div>
+        <PlayerSelector
+          :players="engines"
+          :player-uri="engineURI"
+          :engine-settings="engineSettings.json"
+          :display-thread-state="true"
+          :display-multi-pv-state="true"
+          @update-engine-setting="onUpdatePlayerSetting"
+          @select-player="onSelectPlayer"
+        />
       </div>
       <div class="dialog-main-buttons">
         <button


### PR DESCRIPTION
登録されているエンジン名の最大長が短いか、あるいはエンジンが全く無い場合に検討ダイアログと解析ダイアログのレイアウトが崩れる問題を修正する。