### PR TITLE
Fix USI log

### DIFF
--- a/src/background/usi/engine.ts
+++ b/src/background/usi/engine.ts
@@ -235,11 +235,7 @@ export class EngineProcess {
   }
 
   launch(): void {
-    getUSILogger().info(
-      "sid=%d: launch: %s",
-      this.sessionID,
-      path.dirname(this.path)
-    );
+    getUSILogger().info("sid=%d: launch: %s", this.sessionID, this.path);
     this.timeout = setTimeout(() => {
       if (this.timeoutCallback) {
         this.timeoutCallback();


### PR DESCRIPTION
USI エンジン起動時のログで対象のファイルのパスではなく、親ディレクトリのパスが出力されていた問題を修正する。