### PR TITLE
update css

### DIFF
--- a/src/renderer/view/main/RecordPane.vue
+++ b/src/renderer/view/main/RecordPane.vue
@@ -166,6 +166,12 @@ export default defineComponent({
 }
 .option {
   white-space: nowrap;
-  padding: 0 10px 0 10px;
+  padding: 0 6px 0 6px;
+  margin-right: 4px;
+  background-color: var(--main-bg-color);
+  text-shadow: 1px 1px 2px var(--main-bg-color), 1px 0 2px var(--main-bg-color),
+    1px -1px 2px var(--main-bg-color), 0 1px 2px var(--main-bg-color),
+    0 -1px 2px var(--main-bg-color), -1px 1px 2px var(--main-bg-color),
+    -1px 0 2px var(--main-bg-color), -1px -1px 2px var(--main-bg-color);
 }
 </style>


### PR DESCRIPTION
カスタムの背景画像を使用した場合に、文字が読みづらくなるので影を付ける。