### PR TITLE
fix record view layout

### DIFF
--- a/src/renderer/view/primitive/RecordView.vue
+++ b/src/renderer/view/primitive/RecordView.vue
@@ -48,7 +48,7 @@
         <div
           v-for="branch in branches"
           :key="branch.index"
-          class="move-element"
+          class="row move-element"
           :class="{ selected: branch.selected }"
           :value="branch.index"
           @click="changeBranch(branch.index)"


### PR DESCRIPTION
![スクリーンショット (76)](https://user-images.githubusercontent.com/6257462/228279367-a3fd722a-1794-4ad4-9b1a-290b2a9024ee.png)

分岐リスト内のコメントが次の行に折り返してしまう問題を修正。

この問題は v1.7.0-alpha.1 から発生していた。