### PR TITLE
remove "use strict" from mjs

### DIFF
--- a/scripts/archive.mjs
+++ b/scripts/archive.mjs
@@ -1,5 +1,3 @@
-"use strict";
-
 import archiver from "archiver";
 import fs from "fs";
 

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,5 +1,3 @@
-"use strict"
-
 import builder from "electron-builder";
 import fs from "fs";
 

--- a/scripts/report-license.mjs
+++ b/scripts/report-license.mjs
@@ -1,5 +1,3 @@
-"use strict";
-
 import fs from "fs";
 import path from "path";
 import checker from "license-checker";


### PR DESCRIPTION
.mjs ではデフォルトで Strict モードになるので、冗長な指定を除去する。