### PR TITLE
translate MateSearchDialog

### DIFF
--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -75,6 +75,7 @@ export const en: Texts = {
   repetitionDraw: "Repetition Draw",
   mate: "Mate",
   mateSearch: "Mate Search",
+  startMateSearch: "Start Mate Search",
   stopMateSearch: "Stop Mate Search",
   noMateFound: "No mate.",
   timeout: "Timeout",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -74,6 +74,7 @@ export const ja: Texts = {
   repetitionDraw: "千日手",
   mate: "詰み",
   mateSearch: "詰み探索",
+  startMateSearch: "詰み探索開始",
   stopMateSearch: "詰み探索終了",
   noMateFound: "詰みが見つかりませんでした。",
   timeout: "時間切れ",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -74,6 +74,7 @@ export const zh_tw: Texts = {
   repetitionDraw: "千日手",
   mate: "詰死",
   mateSearch: "詰搜尋",
+  startMateSearch: "開始詰搜尋",
   stopMateSearch: "結束詰搜尋",
   noMateFound: "在目前的盤面中找不到詰。",
   timeout: "時間耗盡",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -72,6 +72,7 @@ export type Texts = {
   repetitionDraw: string;
   mate: string;
   mateSearch: string;
+  startMateSearch: string;
   stopMateSearch: string;
   noMateFound: string;
   timeout: string;

--- a/src/renderer/view/dialog/MateSearchDialog.vue
+++ b/src/renderer/view/dialog/MateSearchDialog.vue
@@ -22,9 +22,9 @@
       </div>
       <div class="main-buttons">
         <button data-hotkey="Enter" autofocus @click="onStart()">
-          詰み探索開始
+          {{ t.startMateSearch }}
         </button>
-        <button data-hotkey="Escape" @click="onCancel()">キャンセル</button>
+        <button data-hotkey="Escape" @click="onCancel()">{{ t.cancel }}</button>
       </div>
     </dialog>
   </div>


### PR DESCRIPTION
# 説明 / Description

MateSearchDialog の多言語対応が漏れていたので修正します。

https://github.com/sunfish-shogi/electron-shogi/issues/489

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
