### PR TITLE
Remove warning message for extended CSA protocol

### DIFF
--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -321,8 +321,6 @@ export const en: Texts = {
     "Please enable log settings and restart this app.",
   notSendPVOnStandardCSAProtocol:
     "Client do not send PV on standard CSA protocol.",
-  sendPVDoNotUseOnWCSC:
-    "Client send PV by floodgate extension. Do not use on WCSC.",
   csaProtocolSendPlaintextPassword:
     "On CSA protocol, client send plaintext password.",
   passwordWillSavedPlaintextBecauseOSSideEncryptionNotAvailable:

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -319,8 +319,6 @@ export const ja: Texts = {
     "アプリ設定からログを有効にしてアプリを再起動してください。",
   notSendPVOnStandardCSAProtocol:
     "標準のCSAプロトコルでは評価値や読み筋が送信されません。",
-  sendPVDoNotUseOnWCSC:
-    "Floodgate仕様で評価値と読み筋を送信します。WCSCで使用しないでください。",
   csaProtocolSendPlaintextPassword:
     "CSAプロトコルの規格上パスワードは平文で送信されます。",
   passwordWillSavedPlaintextBecauseOSSideEncryptionNotAvailable:

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -314,8 +314,6 @@ export const zh_tw: Texts = {
   pleaseEnableLogsAndRestart: "請在程式設定中開啟 log 並重新啟動本程式。",
   notSendPVOnStandardCSAProtocol:
     "在標準的CSA協定中不會送出評價值以及思考棋步。",
-  sendPVDoNotUseOnWCSC:
-    "使用Floodgate形式傳送評價值與思考棋步。請不要在WCSC中使用。",
   csaProtocolSendPlaintextPassword: "在CSA協定中，密碼為明文傳輸。",
   passwordWillSavedPlaintextBecauseOSSideEncryptionNotAvailable:
     "由於無法使用系統的加密機能，輸入的密碼將會以明文保存。",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -308,7 +308,6 @@ export type Texts = {
   logsRecommendedForCSAProtocol: string;
   pleaseEnableLogsAndRestart: string;
   notSendPVOnStandardCSAProtocol: string;
-  sendPVDoNotUseOnWCSC: string;
   csaProtocolSendPlaintextPassword: string;
   passwordWillSavedPlaintextBecauseOSSideEncryptionNotAvailable: string;
   pleaseUncheckSaveHistoryIfNotWantSave: string;

--- a/src/renderer/view/dialog/CSAGameDialog.vue
+++ b/src/renderer/view/dialog/CSAGameDialog.vue
@@ -352,7 +352,8 @@ const onChangeHistory = (event: Event) => {
   const select = event.target as HTMLSelectElement;
   const server = history.value.serverHistory[Number(select.value)];
   if (server) {
-    protocolVersion.value.value = server.protocolVersion;
+    protocolVersion.value.value = selectedProtocolVersion.value =
+      server.protocolVersion;
     host.value.value = server.host;
     port.value.value = server.port;
     id.value.value = server.id;

--- a/src/renderer/view/dialog/CSAGameDialog.vue
+++ b/src/renderer/view/dialog/CSAGameDialog.vue
@@ -66,14 +66,6 @@
               {{ t.notSendPVOnStandardCSAProtocol }}
             </div>
           </div>
-          <div
-            v-if="selectedProtocolVersion === CSAProtocolVersion.V121_FLOODGATE"
-            class="form-group warning"
-          >
-            <div class="note">
-              {{ t.sendPVDoNotUseOnWCSC }}
-            </div>
-          </div>
           <div class="form-item">
             <div class="form-item-label-wide">{{ t.hostToConnect }}</div>
             <input


### PR DESCRIPTION
# 説明 / Description

- 評価値送信を WCSC で使わないよう促すワーニングを廃止する。
https://github.com/sunfish-shogi/electron-shogi/issues/498
- 履歴を使用した際にワーニングが表示されないことがある問題を修正する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
