### PR TITLE
Fix score-mate bug

### DIFF
--- a/src/background/usi/engine.ts
+++ b/src/background/usi/engine.ts
@@ -35,8 +35,11 @@ export enum GameResult {
 function parseScoreMate(arg: string): number {
   switch (arg) {
     case "+":
+    case "+0":
+    case "0":
       return +1;
     case "-":
+    case "-0":
       return -1;
     default:
       return Number(arg);


### PR DESCRIPTION
# 説明 / Description

エンジンから `score mate -0` を送られると、それを正の値として扱っていた問題を修正する。
https://github.com/sunfish-shogi/electron-shogi/issues/507

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
