### PR TITLE
Add defaultRecordFileFormat setting

### DIFF
--- a/src/background/ipc.ts
+++ b/src/background/ipc.ts
@@ -180,6 +180,18 @@ ipcMain.handle(
       throw new Error("failed to open dialog by unexpected error.");
     }
     const appSetting = loadAppSetting();
+    const filters = [
+      { name: "KIF (Shift_JIS)", extensions: ["kif"] },
+      { name: "KIF (UTF-8)", extensions: ["kifu"] },
+      { name: "CSA", extensions: ["csa"] },
+    ];
+    filters.sort((lhs, rhs) => {
+      return defaultPath.endsWith("." + lhs.extensions[0])
+        ? -1
+        : defaultPath.endsWith("." + rhs.extensions[0])
+        ? 1
+        : 0;
+    });
     getAppLogger().debug("show save-record dialog");
     const result = dialog.showSaveDialogSync(win, {
       defaultPath: path.resolve(
@@ -187,11 +199,7 @@ ipcMain.handle(
         defaultPath
       ),
       properties: ["createDirectory", "showOverwriteConfirmation"],
-      filters: [
-        { name: "KIF (Shift-JIS)", extensions: ["kif"] },
-        { name: "KIF (UTF-8)", extensions: ["kifu"] },
-        { name: "CSA", extensions: ["csa"] },
-      ],
+      filters,
     });
     getAppLogger().debug(`save-record dialog result: ${result}`);
     if (!result) {

--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -132,6 +132,7 @@ export const en: Texts = {
   clockSoundTarget: "Clock Sound Target",
   anyTurn: "Any",
   onlyHumanTurn: "Human",
+  defaultRecordFileFormat: "Default Record Format",
   textEncoding: "Text Encoding",
   strict: "Strict",
   autoDetect: "Auto Detect",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -131,6 +131,7 @@ export const ja: Texts = {
   clockSoundTarget: "時計音の対象",
   anyTurn: "全ての手番",
   onlyHumanTurn: "人間の手番のみ",
+  defaultRecordFileFormat: "デフォルトの保存形式",
   textEncoding: "文字コード",
   strict: "厳格",
   autoDetect: "自動判定",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -131,6 +131,7 @@ export const zh_tw: Texts = {
   clockSoundTarget: "棋鐘音效對象",
   anyTurn: "所有手番",
   onlyHumanTurn: "只有玩家手番",
+  defaultRecordFileFormat: "デフォルトの保存形式", // TODO: translate
   textEncoding: "文字編碼",
   strict: "檔案原始編碼",
   autoDetect: "自動判定",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -129,6 +129,7 @@ export type Texts = {
   clockSoundTarget: string;
   anyTurn: string;
   onlyHumanTurn: string;
+  defaultRecordFileFormat: string;
   textEncoding: string;
   strict: string;
   autoDetect: string;

--- a/src/common/settings/app.ts
+++ b/src/common/settings/app.ts
@@ -74,6 +74,12 @@ export enum Tab {
   INVISIBLE = "invisible", // Deprecated
 }
 
+export enum RecordFileFormat {
+  KIF = ".kif",
+  KIFU = ".kifu",
+  CSA = ".csa",
+}
+
 export enum TextDecodingRule {
   STRICT = "strict",
   AUTO_DETECT = "autoDetect",
@@ -120,6 +126,7 @@ export type AppSetting = {
   topPaneHeightPercentage: number;
   topPanePreviousHeightPercentage: number;
   bottomLeftPaneWidthPercentage: number;
+  defaultRecordFileFormat: RecordFileFormat;
   textDecodingRule: TextDecodingRule;
   returnCode: string;
   autoSaveDirectory: string;
@@ -173,6 +180,7 @@ export type AppSettingUpdate = {
   topPaneHeightPercentage?: number;
   topPanePreviousHeightPercentage?: number;
   bottomLeftPaneWidthPercentage?: number;
+  defaultRecordFileFormat?: RecordFileFormat;
   textDecodingRule?: TextDecodingRule;
   returnCode?: string;
   autoSaveDirectory?: string;
@@ -261,6 +269,7 @@ export function defaultAppSetting(opt?: {
     topPaneHeightPercentage: 60,
     topPanePreviousHeightPercentage: 60,
     bottomLeftPaneWidthPercentage: 60,
+    defaultRecordFileFormat: RecordFileFormat.KIF,
     textDecodingRule: TextDecodingRule.AUTO_DETECT,
     returnCode: opt?.returnCode || "\r\n",
     autoSaveDirectory: opt?.autoSaveDirectory || "",

--- a/src/renderer/helpers/path.ts
+++ b/src/renderer/helpers/path.ts
@@ -48,7 +48,8 @@ function getDateStringByMeta(metadata: ImmutableRecordMetadata): string {
 }
 
 export function defaultRecordFileName(
-  metadata: ImmutableRecordMetadata
+  metadata: ImmutableRecordMetadata,
+  extension?: string
 ): string {
   let ret = getDateStringByMeta(metadata);
   const title =
@@ -74,5 +75,12 @@ export function defaultRecordFileName(
   if (white) {
     ret += "_" + white;
   }
-  return escapePath(ret.trim()) + ".kif";
+  return (
+    escapePath(ret.trim()) +
+    (extension
+      ? extension.startsWith(".")
+        ? extension
+        : "." + extension
+      : ".kif")
+  );
 }

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -609,8 +609,11 @@ class Store {
   }
 
   onSaveRecord(): void {
-    const fname = defaultRecordFileName(this.recordManager.record.metadata);
     const appSetting = useAppSetting();
+    const fname = defaultRecordFileName(
+      this.recordManager.record.metadata,
+      appSetting.defaultRecordFileFormat
+    );
     const path = join(appSetting.autoSaveDirectory, fname);
     this.saveRecordByPath(path).catch((e) => {
       this.pushError(`棋譜の保存に失敗しました: ${e}`);
@@ -1029,8 +1032,13 @@ class Store {
         if (options?.overwrite && path) {
           return path;
         }
+        const appSetting = useAppSetting();
         const defaultPath =
-          path || defaultRecordFileName(this.recordManager.record.metadata);
+          path ||
+          defaultRecordFileName(
+            this.recordManager.record.metadata,
+            appSetting.defaultRecordFileFormat
+          );
         return api.showSaveRecordDialog(defaultPath);
       })
       .then((path) => {

--- a/src/renderer/store/setting.ts
+++ b/src/renderer/store/setting.ts
@@ -10,6 +10,7 @@ import {
   PieceImageType,
   PieceStandImageType,
   PositionImageStyle,
+  RecordFileFormat,
   RightSideControlType,
   Tab,
   TabPaneType,
@@ -103,6 +104,9 @@ class AppSettingStore {
   }
   get bottomLeftPaneWidthPercentage(): number {
     return this.setting.bottomLeftPaneWidthPercentage;
+  }
+  get defaultRecordFileFormat(): RecordFileFormat {
+    return this.setting.defaultRecordFileFormat;
   }
   get textDecodingRule(): TextDecodingRule {
     return this.setting.textDecodingRule;

--- a/src/renderer/view/dialog/AppSettingDialog.vue
+++ b/src/renderer/view/dialog/AppSettingDialog.vue
@@ -322,6 +322,26 @@
         <!-- ファイル -->
         <div class="section">
           <div class="section-title">{{ t.file }}</div>
+          <!-- デフォルトの保存形式 -->
+          <div class="form-item">
+            <div class="form-item-label-wide">
+              {{ t.defaultRecordFileFormat }}
+            </div>
+            <HorizontalSelector
+              class="selector"
+              :value="defaultRecordFileFormat"
+              :items="[
+                { label: '.kif (Shift_JIS)', value: RecordFileFormat.KIF },
+                { label: '.kifu (UTF-8)', value: RecordFileFormat.KIFU },
+                { label: '.csa', value: RecordFileFormat.CSA },
+              ]"
+              @change="
+                (value: RecordFileFormat) => {
+                  defaultRecordFileFormat = value;
+                }
+              "
+            />
+          </div>
           <!-- 文字コード -->
           <div class="form-item">
             <div class="form-item-label-wide">
@@ -589,6 +609,7 @@ import {
   AppSettingUpdate,
   Thema,
   BackgroundImageType,
+  RecordFileFormat,
   TextDecodingRule,
   ClockSoundTarget,
 } from "@/common/settings/app";
@@ -645,6 +666,7 @@ const pieceVolume = ref();
 const clockVolume = ref();
 const clockPitch = ref();
 const clockSoundTarget = ref(appSetting.clockSoundTarget);
+const defaultRecordFileFormat = ref(appSetting.defaultRecordFileFormat);
 const textDecodingRule = ref(appSetting.textDecodingRule);
 const returnCode = ref(returnCodeToName[appSetting.returnCode]);
 const autoSaveDirectory = ref();
@@ -701,6 +723,7 @@ const saveAndClose = async () => {
       clockVolume: readInputAsNumber(clockVolume.value),
       clockPitch: readInputAsNumber(clockPitch.value),
       clockSoundTarget: clockSoundTarget.value,
+      defaultRecordFileFormat: defaultRecordFileFormat.value,
       textDecodingRule: textDecodingRule.value,
       returnCode: nameToReturnCode[returnCode.value],
       autoSaveDirectory: autoSaveDirectory.value.value,


### PR DESCRIPTION
# 説明 / Description

https://github.com/sunfish-shogi/electron-shogi/issues/521

デフォルトの棋譜ファイル形式をアプリ設定で選べるようにします。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [x] i18n
