### PR TITLE
associate supported file extensions

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -40,13 +40,38 @@ const config = {
       }
     }
   },
-  win: {},
+  win: {
+    fileAssociations: {
+      name: "Kifu",
+      ext: ["kif", "kifu", "csa"],
+    },
+  },
   nsis: {
     allowElevation: false,
     packElevateHelper: false,
   },
   mac: {
     electronLanguages: ["en", "ja"],
+    fileAssociations: {
+      name: "Kifu",
+      ext: ["kif", "kifu", "csa"],
+    },
+    extendInfo: {
+      CFBundleDocumentTypes: [
+        {
+          CFBundleTypeExtensions: ["kif", "kifu", "csa"],
+          CFBundleTypeName: "Kifu",
+          CFBundleTypeRole: "Editor",
+          LSHandlerRank: "Owner",
+        },
+      ],
+    },
+  },
+  linux: {
+    fileAssociations: {
+      name: "Kifu",
+      ext: ["kif", "kifu", "csa"],
+    },
   },
   publish: null,
 };


### PR DESCRIPTION
# 説明 / Description

#523 

アプリインストール時に棋譜ファイルの拡張子を Electron 将棋に関連付ける。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
