### PR TITLE
Add open-file event handling for macOS

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -126,6 +126,7 @@ function createWindow() {
 
     // macOS では起動後に Finder からファイルを開こうとすると既に存在するプロセスに対して open-file イベントが発生する。
     app.on("open-file", (event, path) => {
+      getAppLogger().info("on open-file: %s", path);
       event.preventDefault();
       if (win.isMinimized()) {
         win.restore();
@@ -143,6 +144,7 @@ app.once("will-finish-launching", () => {
 
   // macOS の Finder でファイルが開かれた場合には process.argv ではなく open-file イベントからパスを取得する必要がある。
   app.once("open-file", (event, path) => {
+    getAppLogger().info("on open-file: %s", path);
     event.preventDefault();
     setInitialFilePath(path);
   });

--- a/src/background/ipc.ts
+++ b/src/background/ipc.ts
@@ -77,8 +77,13 @@ import { getCroppedPieceImageBaseURL } from "@/background/image/cropper";
 
 const isWindows = process.platform === "win32";
 
+let initialFilePath = "";
 let mainWindow: BrowserWindow; // TODO: refactoring
 let appState = AppState.NORMAL;
+
+export function setInitialFilePath(path: string): void {
+  initialFilePath = path;
+}
 
 export function setup(win: BrowserWindow): void {
   mainWindow = win;
@@ -95,7 +100,7 @@ export function getWebContents(): WebContents {
 
 ipcMain.handle(Background.GET_RECORD_PATH_FROM_PROC_ARG, (event) => {
   validateIPCSender(event.senderFrame);
-  const path = process.argv[process.argv.length - 1];
+  const path = process.argv[process.argv.length - 1] || initialFilePath;
   if (isValidRecordFilePath(path)) {
     getAppLogger().debug(`record path from proc arg: ${path}`);
     return path;
@@ -632,6 +637,12 @@ export function onUpdateAppSetting(setting: AppSettingUpdate): void {
     Renderer.UPDATE_APP_SETTING,
     JSON.stringify(setting)
   );
+}
+
+export function openRecord(path: string): void {
+  if (isValidRecordFilePath(path)) {
+    mainWindow.webContents.send(Renderer.OPEN_RECORD, path);
+  }
 }
 
 export function onUSIBestMove(

--- a/src/background/ipc.ts
+++ b/src/background/ipc.ts
@@ -100,7 +100,13 @@ export function getWebContents(): WebContents {
 
 ipcMain.handle(Background.GET_RECORD_PATH_FROM_PROC_ARG, (event) => {
   validateIPCSender(event.senderFrame);
-  const path = process.argv[process.argv.length - 1] || initialFilePath;
+  if (isValidRecordFilePath(initialFilePath)) {
+    getAppLogger().debug(
+      `record path from open-file event: ${initialFilePath}`
+    );
+    return initialFilePath;
+  }
+  const path = process.argv[process.argv.length - 1];
   if (isValidRecordFilePath(path)) {
     getAppLogger().debug(`record path from proc arg: ${path}`);
     return path;

--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -339,6 +339,8 @@ export const en: Texts = {
   areYouSureWantToClearRecord: "Are you sure you want to clear record?",
   areYouSureWantToDiscardPosition:
     "Are you sure you want to discard the position?",
+  areYouSureWantToOpenFileInsteadOfCurrentRecord:
+    "Are you sure you want to open the file instead of current record?",
   youCanNotCloseAppWhileCSAOnlineGame:
     "You can not close app while CSA online game.",
   fileExtensionNotSupported: "File extension is not supported.",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -336,6 +336,8 @@ export const ja: Texts = {
     "中断を要求すると負けになる可能性があります。よろしいですか？",
   areYouSureWantToClearRecord: "現在の棋譜は削除されます。よろしいですか？",
   areYouSureWantToDiscardPosition: "現在の局面は破棄されます。よろしいですか？",
+  areYouSureWantToOpenFileInsteadOfCurrentRecord:
+    "現在の棋譜を閉じて別のファイルを開きます。よろしいですか？",
   youCanNotCloseAppWhileCSAOnlineGame:
     "CSAプロトコル使用中はアプリを終了できません。",
   fileExtensionNotSupported: "取り扱いできないファイル拡張子です。",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -329,6 +329,8 @@ export const zh_tw: Texts = {
   areYouSureWantToRequestQuit: "若提出中斷要求，可能會被判負。請問您要繼續嗎？",
   areYouSureWantToClearRecord: "將會刪除現在的棋譜。請問您要繼續嗎？",
   areYouSureWantToDiscardPosition: "將不會保存現在的局面。請問您要繼續嗎？",
+  areYouSureWantToOpenFileInsteadOfCurrentRecord:
+    "現在の棋譜を閉じて別のファイルを開きます。よろしいですか？", // TODO: translate
   youCanNotCloseAppWhileCSAOnlineGame:
     "由於CSA協定正在使用中，本程式無法被關閉。",
   fileExtensionNotSupported: "無法支援的副檔名。",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -320,6 +320,7 @@ export type Texts = {
   areYouSureWantToRequestQuit: string;
   areYouSureWantToClearRecord: string;
   areYouSureWantToDiscardPosition: string;
+  areYouSureWantToOpenFileInsteadOfCurrentRecord: string;
   youCanNotCloseAppWhileCSAOnlineGame: string;
   fileExtensionNotSupported: string;
   errorOccuredWhileDisconnectingFromCSAServer: string;

--- a/src/common/ipc/channel.ts
+++ b/src/common/ipc/channel.ts
@@ -55,6 +55,7 @@ export enum Renderer {
   SEND_ERROR = "sendError",
   MENU_EVENT = "menuEvent",
   UPDATE_APP_SETTING = "updateAppSetting",
+  OPEN_RECORD = "openRecord",
   USI_BEST_MOVE = "usiBestMove",
   USI_CHECKMATE = "usiCheckmate",
   USI_CHECKMATE_NOT_IMPLEMENTED = "usiCheckmateNotImplemented",

--- a/src/renderer/ipc/api.ts
+++ b/src/renderer/ipc/api.ts
@@ -92,6 +92,7 @@ export interface Bridge {
   onSendError(callback: (e: Error) => void): void;
   onMenuEvent(callback: (event: MenuEvent) => void): void;
   onUpdateAppSetting(callback: (json: string) => void): void;
+  onOpenRecord(callback: (path: string) => void): void;
   onUSIBestMove(
     callback: (
       sessionID: number,

--- a/src/renderer/ipc/preload.ts
+++ b/src/renderer/ipc/preload.ts
@@ -244,6 +244,9 @@ const api: Bridge = {
   onUpdateAppSetting(callback: (json: string) => void): void {
     ipcRenderer.on(Renderer.UPDATE_APP_SETTING, (_, json) => callback(json));
   },
+  onOpenRecord(callback: (path: string) => void): void {
+    ipcRenderer.on(Renderer.OPEN_RECORD, (_, path) => callback(path));
+  },
   onUSIBestMove(
     callback: (
       sessionID: number,

--- a/src/renderer/ipc/setup.ts
+++ b/src/renderer/ipc/setup.ts
@@ -202,6 +202,14 @@ export function setup(): void {
   bridge.onUpdateAppSetting((json: string) => {
     appSetting.updateAppSetting(JSON.parse(json));
   });
+  bridge.onOpenRecord((path: string) => {
+    store.showConfirmation({
+      message: "現在の棋譜を閉じて別のファイルを開きます。よろしいですか？", // TODO i18n
+      onOk: () => {
+        store.openRecord(path);
+      },
+    });
+  });
   bridge.onUSIBestMove(onUSIBestMove);
   bridge.onUSICheckmate(onUSICheckmate);
   bridge.onUSICheckmateNotImplemented(onUSICheckmateNotImplemented);

--- a/src/renderer/ipc/setup.ts
+++ b/src/renderer/ipc/setup.ts
@@ -23,6 +23,7 @@ import {
   onCSAStart,
 } from "@/renderer/store/csa";
 import { useAppSetting } from "@/renderer/store/setting";
+import { t } from "@/common/i18n";
 
 export function setup(): void {
   const store = useStore();
@@ -204,7 +205,7 @@ export function setup(): void {
   });
   bridge.onOpenRecord((path: string) => {
     store.showConfirmation({
-      message: "現在の棋譜を閉じて別のファイルを開きます。よろしいですか？", // TODO i18n
+      message: t.areYouSureWantToOpenFileInsteadOfCurrentRecord,
       onOk: () => {
         store.openRecord(path);
       },

--- a/src/renderer/ipc/web.ts
+++ b/src/renderer/ipc/web.ts
@@ -234,6 +234,9 @@ export const webAPI: Bridge = {
   onUpdateAppSetting(): void {
     // Do Nothing
   },
+  onOpenRecord(): void {
+    // Do Nothing
+  },
   onUSIBestMove(): void {
     // Do Nothing
   },


### PR DESCRIPTION
# 説明 / Description

#522 

macOS の Finder から棋譜ファイルを開けるようにします。

参考:
https://zenn.dev/sprout2000/books/3691a679478de2/viewer/13483
https://zenn.dev/sprout2000/books/3691a679478de2/viewer/13498#macos-%E3%81%AE%E5%A0%B4%E5%90%88

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [x] i18n
