### PR TITLE
fix to use Gyoku as piece of Sente

### DIFF
--- a/src/background/image/cropper.ts
+++ b/src/background/image/cropper.ts
@@ -16,7 +16,7 @@ export function getCroppedPieceImageBaseURL(srcURL: string): string {
 }
 
 const pieces = [
-  "king2",
+  "king",
   "rook",
   "bishop",
   "gold",
@@ -27,7 +27,7 @@ const pieces = [
 ];
 
 const promPieces = [
-  "king",
+  "king2",
   "dragon",
   "horse",
   "",


### PR DESCRIPTION
# 説明 / Description

#532 

カスタム駒画像を使用した場合に、玉（2, 4行目1列）を先手、王（1, 3行目1列）を後手の駒として表示するように修正する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
