### PR TITLE
Add error message when failed to open record by unexpected state

### DIFF
--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -408,6 +408,8 @@ export const en: Texts = {
   mistakeThresholdMustBeLessThanBlunderThreshold:
     "Mistake threshold must be less than blunder threshold.",
   thisEngineNotSupportsMateSearch: "This engine does not support mate search.",
+  pleaseEndActiveFeaturesBeforeOpenRecord:
+    "Please end active features before open record.",
   tryToReloginToCSAServerNSecondsLater: (n) =>
     `Try to relogin to CSA server ${n} seconds later.`,
   mateInNPlyDoYouWantToDisplay: (n) =>

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -414,6 +414,8 @@ export const ja: Texts = {
     "悪手には大悪手より小さい値を指定してください。",
   thisEngineNotSupportsMateSearch:
     "このエンジンは詰将棋探索をサポートしていません。",
+  pleaseEndActiveFeaturesBeforeOpenRecord:
+    "棋譜を開くには現在利用している機能を終了してください。",
   tryToReloginToCSAServerNSecondsLater: (n) =>
     `CSAサーバーへのログインを${n}秒後に再試行します。`,
   mateInNPlyDoYouWantToDisplay: (n) =>

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -395,6 +395,8 @@ export const zh_tw: Texts = {
   dubiousThresholdMustBeLessThanMistakeThreshold: "疑問手門檻應小於惡手門檻。",
   mistakeThresholdMustBeLessThanBlunderThreshold: "惡手門檻應小於大惡手門檻。",
   thisEngineNotSupportsMateSearch: "這個引擎不支援詰將棋搜索。",
+  pleaseEndActiveFeaturesBeforeOpenRecord:
+    "棋譜を開くには現在利用している機能を終了してください。", // TODO: translate
   tryToReloginToCSAServerNSecondsLater: (n) =>
     `請在${n}秒後再次嘗試登入 CSA 伺服器。`,
   mateInNPlyDoYouWantToDisplay: (n) => `尋找到${n}手詰。要顯示結果嗎？`,

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -379,6 +379,7 @@ export type Texts = {
   dubiousThresholdMustBeLessThanMistakeThreshold: string;
   mistakeThresholdMustBeLessThanBlunderThreshold: string;
   thisEngineNotSupportsMateSearch: string;
+  pleaseEndActiveFeaturesBeforeOpenRecord: string;
   tryToReloginToCSAServerNSecondsLater: (n: number) => string;
   mateInNPlyDoYouWantToDisplay: (n: number) => string;
   insertedNMovesToRecord: (n: number) => string;

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -1009,6 +1009,7 @@ class Store {
 
   openRecord(path?: string): void {
     if (this.appState !== AppState.NORMAL || this.isBussy) {
+      this.pushError(t.pleaseEndActiveFeaturesBeforeOpenRecord);
       return;
     }
     this.retainBussyState();

--- a/src/tests/renderer/store/index.spec.ts
+++ b/src/tests/renderer/store/index.spec.ts
@@ -597,7 +597,7 @@ describe("store/index", () => {
     store.openRecord();
     const moves = store.record.moves;
     expect(moves.length).toBe(1);
-    expect(store.hasError).toBeFalsy();
+    expect(store.hasError).toBeTruthy();
     expect(store.recordFilePath).toBeUndefined();
   });
 


### PR DESCRIPTION
# 説明 / Description

ファイルを開けないステータスのときに、ファイルを D&D などで開こうとする行為に対してエラーメッセージを表示する。

関連: https://github.com/sunfish-shogi/electron-shogi/issues/537

![スクリーンショット (115)](https://github.com/sunfish-shogi/electron-shogi/assets/6257462/4018e646-233d-4a42-aa66-2bf6bda571b2)


# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [x] i18n
