### PR TITLE
Fix piece image layout

### DIFF
--- a/src/renderer/view/primitive/BoardView.vue
+++ b/src/renderer/view/primitive/BoardView.vue
@@ -41,7 +41,7 @@
         :style="square.backgroundStyle"
       />
       <div v-for="piece in layout.piece" :key="piece.id" :style="piece.style">
-        <img class="full" :src="piece.imagePath" />
+        <img class="piece-image" :src="piece.imagePath" />
       </div>
       <div v-for="label in layout.labels" :key="label.id" :style="label.style">
         {{ label.character }}
@@ -70,7 +70,7 @@
           :key="piece.id"
           :style="piece.style"
         >
-          <img class="full" :src="piece.imagePath" />
+          <img class="piece-image" :src="piece.imagePath" />
         </div>
         <div
           v-for="pointer in layout.blackHand.pointers"
@@ -96,7 +96,7 @@
           :key="piece.id"
           :style="piece.style"
         >
-          <img class="full" :src="piece.imagePath" />
+          <img class="piece-image" :src="piece.imagePath" />
         </div>
         <div
           v-for="pointer in layout.whiteHand.pointers"
@@ -111,10 +111,13 @@
         :style="layout.promotion.style"
       >
         <div class="select-button promote" @click="clickPromote($event)">
-          <img class="full" :src="layout.promotion.promoteImagePath" />
+          <img class="piece-image" :src="layout.promotion.promoteImagePath" />
         </div>
         <div class="select-button not-promote" @click="clickNotPromote($event)">
-          <img class="full" :src="layout.promotion.notPromoteImagePath" />
+          <img
+            class="piece-image"
+            :src="layout.promotion.notPromoteImagePath"
+          />
         </div>
       </div>
       <div class="turn" :style="layout.turn.style">{{ nextMoveLabel }}</div>
@@ -507,5 +510,9 @@ const whitePlayerTimeSeverity = computed(() => {
   display: flex;
   justify-content: center;
   align-items: center;
+}
+.piece-image {
+  max-width: 100%;
+  max-height: 100%;
 }
 </style>


### PR DESCRIPTION
# 説明 / Description

Electron将棋の初期からあった標準の駒画像と縦横比が異なる画像を使用すると比率が強制的に変えられます。
これを画像素材の比が保たれる様に修正します。

https://github.com/sunfish-shogi/electron-shogi/issues/294#issuecomment-1602573769

**修正前**

![スクリーンショット (116)](https://github.com/sunfish-shogi/electron-shogi/assets/6257462/0142402b-196b-4684-be08-61d042a6663f)

**修正後**

![スクリーンショット (117)](https://github.com/sunfish-shogi/electron-shogi/assets/6257462/42f6cf46-481d-46c2-bb58-496457ba28e1)

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
