### PR TITLE
Fix to send gameover command when game was not ended normally

### DIFF
--- a/src/background/usi/index.ts
+++ b/src/background/usi/index.ts
@@ -163,7 +163,11 @@ export function setupPlayer(
 export function ready(sessionID: number): Promise<void> {
   const session = getSession(sessionID);
   return new Promise<void>((resolve, reject) => {
-    session.process.on("ready", resolve).on("error", reject).ready();
+    session.process.on("ready", resolve).on("error", reject);
+    const error = session.process.ready();
+    if (error) {
+      reject(error);
+    }
   });
 }
 

--- a/src/background/usi/process.ts
+++ b/src/background/usi/process.ts
@@ -5,11 +5,16 @@ import path from "path";
 export class ChildProcess {
   private handle: ChildProcessWithoutNullStreams;
   private readline: Readline | null = null;
+  private _lastSended: string | null = null;
 
   constructor(cmd: string) {
     this.handle = spawn(cmd, {
       cwd: path.dirname(cmd),
     }).on("close", this.onClose.bind(this));
+  }
+
+  get lastSended(): string | null {
+    return this._lastSended;
   }
 
   on(event: "receive", listener: (line: string) => void): this;
@@ -42,6 +47,7 @@ export class ChildProcess {
 
   send(line: string): void {
     this.handle.stdin.write(line + "\n");
+    this._lastSended = line;
   }
 
   kill(): void {

--- a/src/renderer/view/dialog/CSAGameReadyDialog.vue
+++ b/src/renderer/view/dialog/CSAGameReadyDialog.vue
@@ -58,18 +58,17 @@ onBeforeUnmount(() => {
   window.clearInterval(remainingTimer);
 });
 
-watch(
-  () => store.csaGameState,
-  (newState) => {
-    window.clearInterval(remainingTimer);
-    if (newState === CSAGameState.LOGIN_RETRY_INTERVAL) {
-      remainingSeconds.value = loginRetryIntervalSeconds;
-      remainingTimer = window.setInterval(() => {
-        remainingSeconds.value--;
-      }, 1000);
-    }
+const onCSAGameStateUpdated = (newState: CSAGameState) => {
+  window.clearInterval(remainingTimer);
+  if (newState === CSAGameState.LOGIN_RETRY_INTERVAL) {
+    remainingSeconds.value = loginRetryIntervalSeconds;
+    remainingTimer = window.setInterval(() => {
+      remainingSeconds.value--;
+    }, 1000);
   }
-);
+};
+onCSAGameStateUpdated(store.csaGameState);
+watch(() => store.csaGameState, onCSAGameStateUpdated);
 
 const onLogout = () => {
   store.cancelCSAGame();


### PR DESCRIPTION
# 説明 / Description

#558 

USI プロトコル上で isready/readyok/usinewgame のやり取りを完了してから CSA サーバーにログインをしている。
正常に対局を終えた場合には gameover コマンドを送信するが、 CSA サーバーから REJECT された場合や、CSA サーバーとの接続が切れた場合に gameover を送信しない。
この状態のまま再試行すると unexpected state エラーで処理が進まなくなる。

この問題は v1.8 でエンジンプロセスを使い回すようになったことで生じた。
v1.7 ではエンジンプロセスを再試行や対局とともに終了していたので、問題が表面化しなかった。

前回のゲームが終了されないまま ready 関数が呼ばれた場合は、自動的に gameover コマンドを送信してからゲームを終わらせるよう修正する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [ ] i18n
