### PR TITLE
Fix usi ponder info bug

### DIFF
--- a/src/renderer/ipc/setup.ts
+++ b/src/renderer/ipc/setup.ts
@@ -7,6 +7,7 @@ import {
   onUSICheckmateNotImplemented,
   onUSICheckmateTimeout,
   onUSIInfo,
+  onUSIPonderInfo,
   onUSINoMate,
 } from "@/renderer/players/usi";
 import { humanPlayer } from "@/renderer/players/human";
@@ -228,7 +229,7 @@ export function setup(): void {
   });
   bridge.onUSIPonderInfo((sessionID: number, usi: string, json: string) => {
     const info = JSON.parse(json) as USIInfoCommand;
-    onUSIInfo(sessionID, usi, info);
+    onUSIPonderInfo(sessionID, usi, info);
   });
   bridge.onCSAGameSummary((sessionID: number, gameSummary: string): void => {
     onCSAGameSummary(sessionID, JSON.parse(gameSummary));

--- a/src/renderer/players/usi.ts
+++ b/src/renderer/players/usi.ts
@@ -277,6 +277,10 @@ export class USIPlayer implements Player {
 
   private updateUSIInfo(info: SearchInfo) {
     this.info = info;
+    // Ponder 中はハンドラーを呼ばない。
+    if (this.inPonder) {
+      return;
+    }
     // 高頻度でコマンドが送られてくると描画が追いつかないので、一定時間ごとに反映する。
     if (this.usiInfoTimeout) {
       return;


### PR DESCRIPTION
# 説明 / Description

v1.7 から Ponder 中の読み筋と評価値グラフ表示に不具合があった。

- 読み筋: Ponder の読み筋が表示に反映されない。
- 評価値グラフ: Ponder 中に評価値が相手のプロットとして表示される。

setup.ts の書き間違いで onPonderInfo 関数を呼び出せていなかったので修正する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
