### PR TITLE
Fix to save record irrespective of server status

### DIFF
--- a/src/renderer/store/csa.ts
+++ b/src/renderer/store/csa.ts
@@ -234,6 +234,11 @@ export class CSAGameManager {
       return;
     }
 
+    // 自動保存が有効な場合は棋譜を保存する。
+    if (this._state === CSAGameState.GAME && this.setting.enableAutoSave) {
+      this.onSaveRecord();
+    }
+
     // 停止が要求されている場合は連続対局や再試行をしない。
     if (this.stopRequested) {
       reloginBehavior = ReloginBehavior.DO_NOT_RELOGIN;
@@ -419,10 +424,6 @@ export class CSAGameManager {
           break;
       }
       this.player.gameover(result);
-    }
-    // 自動保存が有効な場合は棋譜を保存する。
-    if (this.setting.enableAutoSave) {
-      this.onSaveRecord();
     }
     // セッションを終了する。
     this.close(ReloginBehavior.RELOGIN_IMMEDIATELY);


### PR DESCRIPTION
# 説明 / Description

#561 

コネクションエラー等による対局の中断時にも棋譜を自動保存するように修正します。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
