### PR TITLE
Add menu button for auto-save directory

### DIFF
--- a/src/renderer/view/dialog/AppSettingDialog.vue
+++ b/src/renderer/view/dialog/AppSettingDialog.vue
@@ -406,6 +406,10 @@
             <button class="thin" @click="selectAutoSaveDirectory">
               {{ t.select }}
             </button>
+            <button @click="onOpenAutoSaveDirectory">
+              <Icon :icon="IconType.OPEN_FOLDER" />
+              <div class="label">{{ t.openAutoSavingDirectory }}</div>
+            </button>
           </div>
         </div>
         <hr />
@@ -640,6 +644,8 @@ import { useAppSetting } from "@/renderer/store/setting";
 import { LogLevel } from "@/common/log";
 import HorizontalSelector from "@/renderer/view/primitive/HorizontalSelector.vue";
 import { RecordFileFormat } from "@/common/file";
+import { IconType } from "@/renderer/assets/icons";
+import Icon from "@/renderer/view/primitive/Icon.vue";
 
 enum PieceImage {
   SHINRYU = "shinryu",
@@ -867,6 +873,10 @@ const selectAutoSaveDirectory = async () => {
   } finally {
     store.releaseBussyState();
   }
+};
+
+const onOpenAutoSaveDirectory = () => {
+  api.openExplorer(appSetting.autoSaveDirectory);
 };
 
 const cancel = () => {

--- a/src/renderer/view/menu/FileMenu.vue
+++ b/src/renderer/view/menu/FileMenu.vue
@@ -36,6 +36,10 @@
             <Icon :icon="IconType.GRID" />
             <div class="label">{{ t.positionImage }}</div>
           </button>
+          <button @click="onOpenAutoSaveDirectory">
+            <Icon :icon="IconType.OPEN_FOLDER" />
+            <div class="label">{{ t.openAutoSavingDirectory }}</div>
+          </button>
         </div>
         <div class="group">
           <button @click="onCopyKIF">
@@ -76,10 +80,13 @@ import Icon from "@/renderer/view/primitive/Icon.vue";
 import { IconType } from "@/renderer/assets/icons";
 import { useStore } from "@/renderer/store";
 import { AppState } from "@/common/control/state.js";
+import api from "@/renderer/ipc/api";
+import { useAppSetting } from "@/renderer/store/setting";
 
 const emit = defineEmits(["close"]);
 
 const store = useStore();
+const appSetting = useAppSetting();
 const dialog = ref();
 const onClose = () => {
   emit("close");
@@ -109,6 +116,10 @@ const onBatchConversion = () => {
 };
 const onExportImage = () => {
   store.showExportBoardImageDialog();
+  emit("close");
+};
+const onOpenAutoSaveDirectory = () => {
+  api.openExplorer(appSetting.autoSaveDirectory);
   emit("close");
 };
 const onCopyKIF = () => {


### PR DESCRIPTION
# 説明 / Description

自動保存先をファイルメニューやアプリ設定内から開けるようにボタンを設定する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
