### PR TITLE
Fix app setting dialog

### DIFF
--- a/src/renderer/view/dialog/AppSettingDialog.vue
+++ b/src/renderer/view/dialog/AppSettingDialog.vue
@@ -860,7 +860,7 @@ const selectAutoSaveDirectory = async () => {
 };
 
 const onOpenAutoSaveDirectory = () => {
-  api.openExplorer(appSetting.autoSaveDirectory);
+  api.openExplorer(autoSaveDirectory.value.value);
 };
 
 const cancel = () => {


### PR DESCRIPTION
# 説明 / Description

アプリ設定ダイアログにおいて、ディレクトリを開くボタンが入力中の値ではなく変更前の値を参照していた問題を修正する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
