### PR TITLE
KIF/KI2 の微修正

### DIFF
--- a/src/common/shogi/kakinoki.ts
+++ b/src/common/shogi/kakinoki.ts
@@ -229,7 +229,7 @@ function parseLine(line: string): Line {
       };
     }
   }
-  const metadataPrefix = line.match(/^[^ ]+[：:]/);
+  const metadataPrefix = line.match(/^[^ ：:]+[：:]/);
   if (metadataPrefix) {
     const prefix = metadataPrefix[0];
     return {

--- a/src/common/shogi/kakinoki.ts
+++ b/src/common/shogi/kakinoki.ts
@@ -489,6 +489,8 @@ function readEndOfGame(record: Record, data: string): void {
     record.append(specialMove(SpecialMoveType.FOUL_WIN));
   } else if (clean.endsWith("反則負け")) {
     record.append(specialMove(SpecialMoveType.FOUL_LOSE));
+  } else if (clean.endsWith("入玉勝ち")) {
+    record.append(specialMove(SpecialMoveType.ENTERING_OF_KING));
   } else if (clean.endsWith("勝ち")) {
     record.append(specialMove(SpecialMoveType.RESIGN));
   } else {
@@ -857,6 +859,9 @@ export function exportKI2(
               break;
             case SpecialMoveType.TIMEOUT:
               ret += `時間切れにより${last}の勝ち`;
+              break;
+            case SpecialMoveType.ENTERING_OF_KING:
+              ret += `${next}の入玉勝ち`;
               break;
             case SpecialMoveType.FOUL_WIN:
               ret += `${next}の反則勝ち`;

--- a/src/tests/common/shogi/kakinoki.spec.ts
+++ b/src/tests/common/shogi/kakinoki.spec.ts
@@ -988,6 +988,7 @@ describe("shogi/kakinoki", () => {
 まで107手で後手の反則負け
 まで108手で詰
 まで109手で不詰
+まで296手で先手の入玉勝ち
 `;
     const record = importKI2(data) as Record;
     expect(record).toBeInstanceOf(Record);
@@ -1022,6 +1023,18 @@ describe("shogi/kakinoki", () => {
     record.switchBranchByIndex(7);
     expect(record.current.move as SpecialMove).toStrictEqual(
       specialMove(SpecialMoveType.FOUL_LOSE),
+    );
+    record.switchBranchByIndex(8);
+    expect(record.current.move as SpecialMove).toStrictEqual(
+      specialMove(SpecialMoveType.MATE),
+    );
+    record.switchBranchByIndex(9);
+    expect(record.current.move as SpecialMove).toStrictEqual(
+      specialMove(SpecialMoveType.NO_MATE),
+    );
+    record.switchBranchByIndex(10);
+    expect(record.current.move as SpecialMove).toStrictEqual(
+      specialMove(SpecialMoveType.ENTERING_OF_KING),
     );
   });
 
@@ -1203,6 +1216,7 @@ describe("shogi/kakinoki", () => {
     record.append(SpecialMoveType.FOUL_WIN);
     record.append(SpecialMoveType.FOUL_LOSE);
     record.append(SpecialMoveType.IMPASS);
+    record.append(SpecialMoveType.ENTERING_OF_KING);
     record.append(anySpecialMove("foo"));
     expect(exportKI2(record, {})).toBe(
       `手合割：平手
@@ -1219,6 +1233,9 @@ describe("shogi/kakinoki", () => {
 
 変化：1手
 まで0手で持将棋
+
+変化：1手
+まで0手で先手の入玉勝ち
 
 変化：1手
 まで0手でfoo


### PR DESCRIPTION
# 説明 / Description

- 入玉勝ちのときの最終行の記述を修正
- メタデータの値にコロンが含まれている場合の挙動を修正

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [ ] i18n
