### PR TITLE
平手の場合に USI position コマンドで startpos を使用するように変更

### DIFF
--- a/src/common/shogi/record.ts
+++ b/src/common/shogi/record.ts
@@ -209,7 +209,7 @@ class NodeImpl implements Node {
 }
 
 export type USIFormatOptions = {
-  // 平手の場合に "startpos" を使用するかを指定します。デフォルトは false です。
+  // 平手の場合に "startpos" を使用するかを指定します。デフォルトは true です。
   startpos?: boolean;
   // 投了 "resign" を出力に含めるかどうかを表します。デフォルトは false です。
   resign?: boolean;
@@ -661,7 +661,8 @@ export class Record {
 
   getUSI(opts?: USIFormatOptions): string {
     const sfen = this.initialPosition.sfen;
-    const useStartpos = opts?.startpos && sfen === InitialPositionSFEN.STANDARD;
+    const useStartpos =
+      (opts?.startpos === undefined || opts.startpos) && sfen === InitialPositionSFEN.STANDARD;
     let ret =
       "position " + (useStartpos ? "startpos" : "sfen " + this.initialPosition.sfen) + " moves";
     for (let p = this.first; ; p = p.next) {

--- a/src/tests/common/shogi/record.spec.ts
+++ b/src/tests/common/shogi/record.spec.ts
@@ -50,14 +50,16 @@ describe("shogi/record", () => {
 `;
     const record = importKIF(data) as Record;
     record.goto(2);
-    expect(record.usi).toBe(
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 2g2f 8c8d",
-    );
+    expect(record.usi).toBe("position startpos moves 2g2f 8c8d");
+    expect(record.getUSI()).toBe("position startpos moves 2g2f 8c8d");
+    expect(record.getUSI({ startpos: true })).toBe("position startpos moves 2g2f 8c8d");
     expect(
       record.getUSI({
-        startpos: true,
+        startpos: false,
       }),
-    ).toBe("position startpos moves 2g2f 8c8d");
+    ).toBe(
+      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 2g2f 8c8d",
+    );
     expect(
       record.getUSI({
         startpos: true,
@@ -114,9 +116,7 @@ describe("shogi/record", () => {
     expect(onChangePosition).toBeCalledTimes(9);
     expect(record.goBack()).toBeTruthy();
     expect(onChangePosition).toBeCalledTimes(10);
-    expect(record.usi).toBe(
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves",
-    );
+    expect(record.usi).toBe("position startpos moves");
     expect(record.goBack()).toBeFalsy();
     expect(onChangePosition).toBeCalledTimes(10); // not called
 
@@ -124,24 +124,18 @@ describe("shogi/record", () => {
     expect(onChangePosition).toBeCalledTimes(11);
     record.goto(Number.MAX_SAFE_INTEGER);
     expect(onChangePosition).toBeCalledTimes(12);
-    expect(record.usi).toBe(
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 8c8d 7i7h",
-    );
+    expect(record.usi).toBe("position startpos moves 7g7f 8c8d 7i7h");
     expect(record.goForward()).toBeFalsy();
     expect(onChangePosition).toBeCalledTimes(12); // not called
 
     record.goto(2);
     expect(onChangePosition).toBeCalledTimes(13);
-    expect(record.usi).toBe(
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 8c8d",
-    );
+    expect(record.usi).toBe("position startpos moves 7g7f 8c8d");
     record.goto(2);
     expect(onChangePosition).toBeCalledTimes(13); // not called
     expect(record.switchBranchByIndex(0)).toBeTruthy();
     expect(onChangePosition).toBeCalledTimes(14);
-    expect(record.usi).toBe(
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d",
-    );
+    expect(record.usi).toBe("position startpos moves 7g7f 3c3d");
   });
 
   it("repetition", () => {

--- a/src/tests/renderer/players/usi.spec.ts
+++ b/src/tests/renderer/players/usi.spec.ts
@@ -18,12 +18,9 @@ describe("usi", () => {
     mockAPI.usiGo.mockResolvedValueOnce();
     mockAPI.usiGoPonder.mockResolvedValueOnce();
     mockAPI.usiPonderHit.mockResolvedValueOnce();
-    const usi1 =
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d";
-    const usi2 =
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f";
-    const usi3 =
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f 8c8d";
+    const usi1 = "position startpos moves 7g7f 3c3d";
+    const usi2 = "position startpos moves 7g7f 3c3d 2g2f";
+    const usi3 = "position startpos moves 7g7f 3c3d 2g2f 8c8d";
     const record1 = Record.newByUSI(usi1) as Record;
     const record2 = Record.newByUSI(usi2) as Record;
     const record3 = Record.newByUSI(usi3) as Record;

--- a/src/tests/renderer/store/csa.spec.ts
+++ b/src/tests/renderer/store/csa.spec.ts
@@ -64,19 +64,17 @@ describe("store/csa", () => {
     mockAPI.csaMove.mockResolvedValue();
     mockAPI.csaLogout.mockResolvedValueOnce();
     const mockPlayer = createMockPlayer({
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves": {
+      "position startpos moves": {
         usi: "7g7f",
         info: { score: 82, pv: ["3c3d", "2g2f", "8c8d"] },
       },
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d":
-        {
-          usi: "2g2f",
-          info: { score: 78, pv: ["8c8d", "2f2e", "8d8e"] },
-        },
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f 8c8d":
-        {
-          usi: "resign",
-        },
+      "position startpos moves 7g7f 3c3d": {
+        usi: "2g2f",
+        info: { score: 78, pv: ["8c8d", "2f2e", "8d8e"] },
+      },
+      "position startpos moves 7g7f 3c3d 2g2f 8c8d": {
+        usi: "resign",
+      },
     });
     const mockPlayerBuilder = createMockPlayerBuilder({
       [playerURI]: mockPlayer,
@@ -169,19 +167,17 @@ describe("store/csa", () => {
     mockAPI.csaMove.mockResolvedValue();
     mockAPI.csaLogout.mockResolvedValue();
     const mockPlayer = createMockPlayer({
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves": {
+      "position startpos moves": {
         usi: "7g7f",
         info: { score: 82, pv: ["3c3d", "2g2f", "8c8d"] },
       },
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d":
-        {
-          usi: "2g2f",
-          info: { score: 78, pv: ["8c8d", "2f2e", "8d8e"] },
-        },
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f 8c8d":
-        {
-          usi: "resign",
-        },
+      "position startpos moves 7g7f 3c3d": {
+        usi: "2g2f",
+        info: { score: 78, pv: ["8c8d", "2f2e", "8d8e"] },
+      },
+      "position startpos moves 7g7f 3c3d 2g2f 8c8d": {
+        usi: "resign",
+      },
     });
     const mockPlayerBuilder = createMockPlayerBuilder({
       [playerURI]: mockPlayer,
@@ -299,14 +295,11 @@ describe("store/csa", () => {
     mockAPI.csaMove.mockResolvedValue();
     mockAPI.csaLogout.mockResolvedValueOnce();
     const mockPlayer = createMockPlayer({
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 3g3f 3c3d 3i4h 4a3b":
-        {
-          usi: "4h3g",
-        },
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 3g3f 3c3d 3i4h 4a3b 4h3g 8c8d":
-        { usi: "2g2f" },
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 3g3f 3c3d 3i4h 4a3b 4h3g 8c8d 2g2f 8d8e":
-        { usi: "resign" },
+      "position startpos moves 3g3f 3c3d 3i4h 4a3b": {
+        usi: "4h3g",
+      },
+      "position startpos moves 3g3f 3c3d 3i4h 4a3b 4h3g 8c8d": { usi: "2g2f" },
+      "position startpos moves 3g3f 3c3d 3i4h 4a3b 4h3g 8c8d 2g2f 8d8e": { usi: "resign" },
     });
     const mockPlayerBuilder = createMockPlayerBuilder({
       [playerURI]: mockPlayer,

--- a/src/tests/renderer/store/game.spec.ts
+++ b/src/tests/renderer/store/game.spec.ts
@@ -70,25 +70,23 @@ describe("store/game", () => {
 
   it("GameManager/resign", () => {
     const mockBlackPlayer = createMockPlayer({
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves": {
+      "position startpos moves": {
         usi: "7g7f",
         info: { score: 82, pv: ["3c3d", "2g2f", "8c8d"] },
       },
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d":
-        {
-          usi: "2g2f",
-          info: { score: 78, pv: ["8c8d", "2f2e", "8d8e"] },
-        },
+      "position startpos moves 7g7f 3c3d": {
+        usi: "2g2f",
+        info: { score: 78, pv: ["8c8d", "2f2e", "8d8e"] },
+      },
     });
     const mockWhitePlayer = createMockPlayer({
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f": {
+      "position startpos moves 7g7f": {
         usi: "3c3d",
         info: { score: 64, pv: ["2g2f", "8c8d"] },
       },
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f":
-        {
-          usi: "resign",
-        },
+      "position startpos moves 7g7f 3c3d 2g2f": {
+        usi: "resign",
+      },
     });
     const mockPlayerBuilder = createMockPlayerBuilder({
       [playerURI01]: mockBlackPlayer,
@@ -126,9 +124,7 @@ describe("store/game", () => {
         expect(mockHandlers.onBeepShort).toBeCalledTimes(0);
         expect(mockHandlers.onBeepUnlimited).toBeCalledTimes(0);
         expect(mockHandlers.onStopBeep).toBeCalledTimes(8);
-        expect(recordManager.record.usi).toBe(
-          "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f",
-        );
+        expect(recordManager.record.usi).toBe("position startpos moves 7g7f 3c3d 2g2f");
         expect(recordManager.record.moves[1].comment).toBe(
           "互角\n*評価値=82\n*読み筋=△３四歩▲２六歩△８四歩\n",
         );
@@ -199,20 +195,18 @@ describe("store/game", () => {
 
   it("GameManager/endGame", () => {
     const mockBlackPlayer = createMockPlayer({
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves": {
+      "position startpos moves": {
         usi: "7g7f",
       },
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d":
-        { usi: "2g2f" },
+      "position startpos moves 7g7f 3c3d": { usi: "2g2f" },
     });
     const mockWhitePlayer = createMockPlayer({
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f": {
+      "position startpos moves 7g7f": {
         usi: "3c3d",
       },
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f":
-        {
-          usi: "no-reply",
-        },
+      "position startpos moves 7g7f 3c3d 2g2f": {
+        usi: "no-reply",
+      },
     });
     const mockPlayerBuilder = createMockPlayerBuilder({
       [playerURI01]: mockBlackPlayer,
@@ -250,9 +244,7 @@ describe("store/game", () => {
         expect(mockHandlers.onBeepShort).toBeCalledTimes(0);
         expect(mockHandlers.onBeepUnlimited).toBeCalledTimes(0);
         expect(mockHandlers.onStopBeep).toBeCalledTimes(8);
-        expect(recordManager.record.usi).toBe(
-          "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f",
-        );
+        expect(recordManager.record.usi).toBe("position startpos moves 7g7f 3c3d 2g2f");
       },
       (manager) => {
         setTimeout(() => manager.endGame(SpecialMoveType.INTERRUPT), 100);
@@ -263,33 +255,30 @@ describe("store/game", () => {
   it("GameManager/resign/twice", () => {
     const mockBlackPlayer = createMockPlayer({
       // 1st game
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves": {
+      "position startpos moves": {
         usi: "7g7f",
       },
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d":
-        { usi: "2g2f" },
+      "position startpos moves 7g7f 3c3d": { usi: "2g2f" },
       // 2nd game
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f": {
+      "position startpos moves 7g7f": {
         usi: "3c3d",
       },
     });
     const mockWhitePlayer = createMockPlayer({
       // 1st game
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f": {
+      "position startpos moves 7g7f": {
         usi: "3c3d",
       },
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f":
-        {
-          usi: "resign",
-        },
+      "position startpos moves 7g7f 3c3d 2g2f": {
+        usi: "resign",
+      },
       // 2nd game
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves": {
+      "position startpos moves": {
         usi: "7g7f",
       },
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d":
-        {
-          usi: "resign",
-        },
+      "position startpos moves 7g7f 3c3d": {
+        usi: "resign",
+      },
     });
     const mockPlayerBuilder = createMockPlayerBuilder({
       [playerURI01]: mockBlackPlayer,
@@ -333,26 +322,22 @@ describe("store/game", () => {
         expect(mockHandlers.onBeepShort).toBeCalledTimes(0);
         expect(mockHandlers.onBeepUnlimited).toBeCalledTimes(0);
         expect(mockHandlers.onStopBeep).toBeCalledTimes(14);
-        expect(recordManager.record.usi).toBe(
-          "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d",
-        );
+        expect(recordManager.record.usi).toBe("position startpos moves 7g7f 3c3d");
       },
     );
   });
 
   it("GameManager/noStartPosition/twice", () => {
     const mockBlackPlayer = createMockPlayer({
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d":
-        { usi: "2g2f" },
+      "position startpos moves 7g7f 3c3d": { usi: "2g2f" },
     });
     const mockWhitePlayer = createMockPlayer({
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f": {
+      "position startpos moves 7g7f": {
         usi: "3c3d",
       },
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f":
-        {
-          usi: "resign",
-        },
+      "position startpos moves 7g7f 3c3d 2g2f": {
+        usi: "resign",
+      },
     });
     const mockPlayerBuilder = createMockPlayerBuilder({
       [playerURI01]: mockBlackPlayer,
@@ -399,29 +384,25 @@ describe("store/game", () => {
         expect(mockHandlers.onBeepShort).toBeCalledTimes(0);
         expect(mockHandlers.onBeepUnlimited).toBeCalledTimes(0);
         expect(mockHandlers.onStopBeep).toBeCalledTimes(12);
-        expect(recordManager.record.usi).toBe(
-          "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f",
-        );
+        expect(recordManager.record.usi).toBe("position startpos moves 7g7f 3c3d 2g2f");
       },
     );
   });
 
   it("GameManager/maxMoves", () => {
     const mockBlackPlayer = createMockPlayer({
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves": {
+      "position startpos moves": {
         usi: "7g7f",
       },
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d":
-        { usi: "2g2f" },
+      "position startpos moves 7g7f 3c3d": { usi: "2g2f" },
     });
     const mockWhitePlayer = createMockPlayer({
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f": {
+      "position startpos moves 7g7f": {
         usi: "3c3d",
       },
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f":
-        {
-          usi: "8c8d",
-        },
+      "position startpos moves 7g7f 3c3d 2g2f": {
+        usi: "8c8d",
+      },
     });
     const mockPlayerBuilder = createMockPlayerBuilder({
       [playerURI01]: mockBlackPlayer,
@@ -460,9 +441,7 @@ describe("store/game", () => {
         expect(mockHandlers.onBeepShort).toBeCalledTimes(0);
         expect(mockHandlers.onBeepUnlimited).toBeCalledTimes(0);
         expect(mockHandlers.onStopBeep).toBeCalledTimes(9);
-        expect(recordManager.record.usi).toBe(
-          "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d 2g2f 8c8d",
-        );
+        expect(recordManager.record.usi).toBe("position startpos moves 7g7f 3c3d 2g2f 8c8d");
       },
     );
   });

--- a/src/tests/renderer/store/index.spec.ts
+++ b/src/tests/renderer/store/index.spec.ts
@@ -193,8 +193,7 @@ describe("store/index", () => {
 
   it("updateUSIInfo", () => {
     jest.useFakeTimers();
-    const usi =
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f";
+    const usi = "position startpos moves 7g7f";
     const store = createStore();
     store.pasteRecord(usi);
     store.updateUSIInfo(101, usi, "Engine A", {
@@ -229,10 +228,8 @@ describe("store/index", () => {
 
   it("updateUSIPonderInfo", () => {
     jest.useFakeTimers();
-    const usi =
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f";
-    const usi2 =
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f 3c3d";
+    const usi = "position startpos moves 7g7f";
+    const usi2 = "position startpos moves 7g7f 3c3d";
     const store = createStore();
     store.pasteRecord(usi);
     store.updateUSIPonderInfo(101, usi2, "Engine A", {

--- a/src/tests/renderer/store/research.spec.ts
+++ b/src/tests/renderer/store/research.spec.ts
@@ -29,10 +29,7 @@ describe("store/research", () => {
     manager.updatePosition(record);
     jest.runOnlyPendingTimers(); // 遅延実行
     expect(mockAPI.usiGoInfinite).toBeCalledTimes(1);
-    expect(mockAPI.usiGoInfinite).toBeCalledWith(
-      100,
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves",
-    );
+    expect(mockAPI.usiGoInfinite).toBeCalledWith(100, "position startpos moves");
 
     // 時間制限が無いので stop コマンドは送信されない。
     jest.runOnlyPendingTimers();
@@ -42,10 +39,7 @@ describe("store/research", () => {
     manager.updatePosition(record);
     jest.runOnlyPendingTimers(); // 遅延実行
     expect(mockAPI.usiGoInfinite).toBeCalledTimes(2);
-    expect(mockAPI.usiGoInfinite).toBeCalledWith(
-      100,
-      "position sfen lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1 moves 7g7f",
-    );
+    expect(mockAPI.usiGoInfinite).toBeCalledWith(100, "position startpos moves 7g7f");
   });
 
   it("max5Seconds", async () => {


### PR DESCRIPTION
# 説明 / Description

USI プロトコルの仕様によれば、平手の初期局面は SFEN ではなく startpos を使うことが推奨されているように読める。

http://shogidokoro.starfree.jp/usi.html

> 初期局面の部分については、平手初期局面であれば単にstartposと書き、そうでなければsfenに続けてSFENの書式に基づいて記述します。

このドキュメント自体は将棋所を強く意識した内容なので、どの程度の推奨事項なのかニュアンスが微妙なところはあるが従う方が無難だと思うのでそうする。
これによってコマンドの文字数が減る。パフォーマンス上の違いは誤差だと思うが、ログが見やすくなるメリットが有る。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [ ] i18n
