### PR TITLE
Add in-comment metadata: "詰み"

### DIFF
--- a/src/background/usi/engine.ts
+++ b/src/background/usi/engine.ts
@@ -7,7 +7,7 @@ import {
   USIPonder,
 } from "@/common/settings/usi";
 import { Logger } from "log4js";
-import { USIInfoCommand } from "@/common/usi";
+import { SCORE_MATE_INFINITE, USIInfoCommand } from "@/common/usi";
 import { ChildProcess } from "./process";
 
 export type EngineProcessOption = {
@@ -34,10 +34,10 @@ function parseScoreMate(arg: string): number {
     case "+":
     case "+0":
     case "0":
-      return +1;
+      return +SCORE_MATE_INFINITE;
     case "-":
     case "-0":
-      return -1;
+      return -SCORE_MATE_INFINITE;
     default:
       return Number(arg);
   }

--- a/src/common/usi.ts
+++ b/src/common/usi.ts
@@ -1,5 +1,8 @@
 import { ImmutablePosition, Move } from "@/common/shogi";
 
+// SCORE_MATE_INFINITE は詰みを発見したが手数までは確定していない場合に使用する値です。
+export const SCORE_MATE_INFINITE = 10000;
+
 export type USIInfoCommand = {
   depth?: number;
   seldepth?: number;

--- a/src/tests/background/usi/engine.spec.ts
+++ b/src/tests/background/usi/engine.spec.ts
@@ -272,7 +272,7 @@ describe("ipc/background/usi/engine", () => {
     onReceive("info depth 3 score mate -");
     expect(handlers.info).lastCalledWith("position test02", {
       depth: 3,
-      scoreMate: -1,
+      scoreMate: -10000,
     });
     engine.stop();
     expect(mockChildProcess.prototype.send).lastCalledWith("stop");

--- a/src/tests/renderer/store/record.spec.ts
+++ b/src/tests/renderer/store/record.spec.ts
@@ -1,5 +1,6 @@
 import { CommentBehavior } from "@/common/settings/analysis";
 import { Color, Move, PieceType, Square } from "@/common/shogi";
+import { SCORE_MATE_INFINITE } from "@/common/usi";
 import { RecordManager, SearchInfoSenderType } from "@/renderer/store/record";
 
 describe("store/record", () => {
@@ -36,9 +37,6 @@ describe("store/record", () => {
         engineName: "Engine01",
       },
     );
-    expect(recordManager.record.current.comment).toBe(
-      "互角\n#評価値=158\n#読み筋=▲７六歩△３四歩\n#深さ=8\n#エンジン=Engine01\n",
-    );
     recordManager.appendSearchComment(
       SearchInfoSenderType.PLAYER,
       {
@@ -56,6 +54,25 @@ describe("store/record", () => {
     );
   });
 
+  it("appendSearchComment/mate", () => {
+    const recordManager = new RecordManager();
+    recordManager.appendSearchComment(
+      SearchInfoSenderType.PLAYER,
+      { mate: 15 },
+      CommentBehavior.APPEND,
+      { engineName: "Engine01" },
+    );
+    recordManager.appendSearchComment(
+      SearchInfoSenderType.RESEARCHER,
+      { mate: -SCORE_MATE_INFINITE },
+      CommentBehavior.APPEND,
+      { engineName: "Engine02" },
+    );
+    expect(recordManager.record.current.comment).toBe(
+      "*詰み=先手勝ち:15手\n*エンジン=Engine01\n\n#詰み=後手勝ち\n#エンジン=Engine02\n",
+    );
+  });
+
   it("appendMovesSilently", () => {
     const recordManager = new RecordManager();
     recordManager.appendMovesSilently([
@@ -64,5 +81,41 @@ describe("store/record", () => {
     ]);
     expect(recordManager.record.current.ply).toBe(0);
     expect(recordManager.record.moves).toHaveLength(3);
+  });
+
+  it("importRecord", () => {
+    const recordManager = new RecordManager();
+    const error = recordManager.importRecord(`手合割：平手
+手数----指手---------消費時間--
+   1 ２六歩(27)   ( 0:00/00:00:00)
+   2 ８四歩(83)   ( 0:00/00:00:00)
+**評価値=80
+*
+*#評価値=-60
+   3 ７六歩(77)   ( 0:00/00:00:00)
+**詰み=先手勝ち
+*
+*#詰み=後手勝ち
+   4 ８五歩(84)   ( 0:00/00:00:00)
+**詰み=先手勝ち:15手
+*
+*#詰み=後手勝ち:8手
+`);
+    expect(error).toBeUndefined();
+    recordManager.changePly(2);
+    expect(recordManager.record.current.customData).toStrictEqual({
+      playerSearchInfo: { score: 80 },
+      researchInfo: { score: -60 },
+    });
+    recordManager.changePly(3);
+    expect(recordManager.record.current.customData).toStrictEqual({
+      playerSearchInfo: { mate: SCORE_MATE_INFINITE },
+      researchInfo: { mate: -SCORE_MATE_INFINITE },
+    });
+    recordManager.changePly(4);
+    expect(recordManager.record.current.customData).toStrictEqual({
+      playerSearchInfo: { mate: 15 },
+      researchInfo: { mate: -8 },
+    });
   });
 });


### PR DESCRIPTION
# 説明 / Description

#591 

コメント内メタデータ「詰み」を実装する。

仕様: https://github.com/sunfish-shogi/electron-shogi/wiki/%E6%80%9D%E8%80%83%E3%82%B3%E3%83%A1%E3%83%B3%E3%83%88%E3%81%AE%E4%BB%95%E6%A7%98%EF%BC%88%E3%83%89%E3%83%A9%E3%83%95%E3%83%88%EF%BC%89

![スクリーンショット (138)](https://github.com/sunfish-shogi/electron-shogi/assets/6257462/5fde7a14-46cb-4520-972e-2bad5c91a327)
![スクリーンショット (139)](https://github.com/sunfish-shogi/electron-shogi/assets/6257462/bffe9eae-b5e9-409b-bc1b-85f4e3efdfae)

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [ ] i18n
