### PR TITLE
Fix to add "なし" to KIF

### DIFF
--- a/src/common/shogi/kakinoki.ts
+++ b/src/common/shogi/kakinoki.ts
@@ -743,6 +743,9 @@ function formatHand(hand: ImmutableHand): string {
       ret += "　";
     }
   });
+  if (ret === "") {
+    ret = "なし";
+  }
   return ret;
 }
 

--- a/src/tests/common/shogi/kakinoki.spec.ts
+++ b/src/tests/common/shogi/kakinoki.spec.ts
@@ -1130,6 +1130,24 @@ describe("shogi/kakinoki", () => {
 先手の持駒：歩二　
 後手番`,
       },
+      {
+        sfen: "ln1g2snl/1rs1k1gb1/p1ppppppp/9/1p5P1/9/PPPPPPP1P/1BGK2SR1/LNS2G1NL b - 1",
+        want: `後手の持駒：なし
+  ９ ８ ７ ６ ５ ４ ３ ２ １
++---------------------------+
+|v香v桂 ・v金 ・ ・v銀v桂v香|一
+| ・v飛v銀 ・v玉 ・v金v角 ・|二
+|v歩 ・v歩v歩v歩v歩v歩v歩v歩|三
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|四
+| ・v歩 ・ ・ ・ ・ ・ 歩 ・|五
+| ・ ・ ・ ・ ・ ・ ・ ・ ・|六
+| 歩 歩 歩 歩 歩 歩 歩 ・ 歩|七
+| ・ 角 金 玉 ・ ・ 銀 飛 ・|八
+| 香 桂 銀 ・ ・ 金 ・ 桂 香|九
++---------------------------+
+先手の持駒：なし
+先手番`,
+      },
     ];
     for (const tc of testCases) {
       const record = new Record(Position.newBySFEN(tc.sfen) as Position);


### PR DESCRIPTION
# 説明 / Description

KIF 形式で出力する際、持ち駒がない場合に `なし` を書くように修正する。
この仕様に関するドキュメントは見当たらないが、 Kif for Windows や ShogiGUI がそのような書き方をしている。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
