### PR TITLE
Fix CSA file comment

### DIFF
--- a/src/common/shogi/csa.ts
+++ b/src/common/shogi/csa.ts
@@ -559,18 +559,17 @@ export function exportCSA(record: ImmutableRecord, options: CSAExportOptions): s
   ret += formatMetadata(record.metadata, options);
   ret += formatPosition(record.initialPosition, options);
   record.moves.forEach((node) => {
-    if (node.ply === 0) {
-      return;
-    }
-    let move: string | undefined;
-    if (node.move instanceof Move) {
-      move = formatMove(node.move);
-    } else {
-      move = formatSpecialMove(node.move);
-    }
-    if (move) {
-      ret += move + returnCode;
-      ret += "T" + Math.floor(node.elapsedMs / 1e3) + returnCode;
+    if (node.ply !== 0) {
+      let move: string | undefined;
+      if (node.move instanceof Move) {
+        move = formatMove(node.move);
+      } else {
+        move = formatSpecialMove(node.move);
+      }
+      if (move) {
+        ret += move + returnCode;
+        ret += "T" + Math.floor(node.elapsedMs / 1e3) + returnCode;
+      }
     }
     if (node.comment) {
       const comment = node.comment.endsWith("\n") ? node.comment.slice(0, -1) : node.comment;

--- a/src/tests/common/shogi/csa.spec.ts
+++ b/src/tests/common/shogi/csa.spec.ts
@@ -645,6 +645,7 @@ PI
     record.metadata.setStandardMetadata(RecordMetadataKey.BLACK_NAME, "Electron John");
     record.metadata.setStandardMetadata(RecordMetadataKey.WHITE_NAME, "Mr.Vue");
     record.metadata.setStandardMetadata(RecordMetadataKey.TITLE, "TypeScript Festival");
+    record.current.comment = "初期局面へのコメント\n";
     record.append(record.position.createMoveByUSI("7g7f") as Move);
     record.append(record.position.createMoveByUSI("3c3d") as Move);
     record.current.comment = "2手目へのコメント\n2手目へのコメント2\n";
@@ -662,6 +663,7 @@ N-Mr.Vue
 $EVENT:TypeScript Festival
 PI
 +
+'*初期局面へのコメント
 +7776FU
 T0
 -3334FU


### PR DESCRIPTION
# 説明 / Description

棋譜を CSA 形式で保存したときに初期局面のコメントが記録されない問題を修正。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [ ] i18n
