### PR TITLE
拡張子が大文字のファイルを許容するように修正

### DIFF
--- a/src/background/ipc.ts
+++ b/src/background/ipc.ts
@@ -124,13 +124,14 @@ ipcMain.on(Background.OPEN_EXPLORER, (_, targetPath: string) => {
 });
 
 function isValidRecordFilePath(path: string) {
+  const lowerCasePath = path.toLowerCase();
   return (
-    path.endsWith(".kif") ||
-    path.endsWith(".kifu") ||
-    path.endsWith(".ki2") ||
-    path.endsWith(".ki2u") ||
-    path.endsWith(".csa") ||
-    path.endsWith(".jkf")
+    lowerCasePath.endsWith(".kif") ||
+    lowerCasePath.endsWith(".kifu") ||
+    lowerCasePath.endsWith(".ki2") ||
+    lowerCasePath.endsWith(".ki2u") ||
+    lowerCasePath.endsWith(".csa") ||
+    lowerCasePath.endsWith(".jkf")
   );
 }
 


### PR DESCRIPTION
# 説明 / Description

拡張子が大文字の棋譜ファイルを開けるように修正する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
