### PR TITLE
ファイル形式ごとに保存されないデータを知らせる機能

### DIFF
--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -186,6 +186,7 @@ export const en: Texts = {
   recordProperties: "Record Properties",
   comments: "Comments",
   commentsAndBookmarks: "Comments & Bookmarks",
+  branches: "Branches",
   bookmark: "Bookmark",
   bookmarkList: "Bookmarks",
   useBookmarkAsHeader: "Use Bookmark as Header",
@@ -443,6 +444,8 @@ export const en: Texts = {
   addNthEngine: (n) => `Add ${ordinal(n)} engine`,
   copyOf: (name) => `${name} (copy)`,
   keepLatest: (n) => `keep latest ${n}`,
+  followingDataNotSavedBecauseNotSupporetedBy: (fileFormat: string) =>
+    `Following data not saved because not supporeted by "${fileFormat}".`,
   areYouSureWantToDeleteFollowingMove: (n) =>
     `Are you sure you want to delete ${n}th move and the following move?`,
   failedToOpenDirectory: (path: string) => `Failed to open directory of the file: ${path}`,

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -185,6 +185,7 @@ export const ja: Texts = {
   recordProperties: "棋譜情報",
   comments: "コメント",
   commentsAndBookmarks: "コメント・しおり",
+  branches: "分岐",
   bookmark: "しおり",
   bookmarkList: "しおり一覧",
   useBookmarkAsHeader: "しおりを見出しに使う",
@@ -439,6 +440,8 @@ export const ja: Texts = {
   addNthEngine: (n) => `${n} 個目のエンジンを追加`,
   copyOf: (name) => `${name} のコピー`,
   keepLatest: (n) => `最新${n}件まで`,
+  followingDataNotSavedBecauseNotSupporetedBy: (fileFormat: string) =>
+    `以下の情報は ${fileFormat} 形式では対応していないため保存されませんでした。`,
   areYouSureWantToDeleteFollowingMove: (n) => `${n}手目以降を削除します。よろしいですか？`,
   failedToOpenDirectory: (path) => `ファイルの場所を開けませんでした: ${path}`,
   unexpectedEventSenderPleaseReport(sender) {

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -185,6 +185,7 @@ export const zh_tw: Texts = {
   recordProperties: "棋譜情報",
   comments: "備註",
   commentsAndBookmarks: "備註・書籤",
+  branches: "分岐", // TODO: translate
   bookmark: "書籤",
   bookmarkList: "書籤一覽",
   useBookmarkAsHeader: "將書籤名稱作為標題",
@@ -433,6 +434,8 @@ export const zh_tw: Texts = {
   addNthEngine: (n) => `追加第 ${n} 個引擎`,
   copyOf: (name) => `${name} 的拷貝`,
   keepLatest: (n) => `到最新${n}件`,
+  followingDataNotSavedBecauseNotSupporetedBy: (fileFormat: string) =>
+    `以下の情報は ${fileFormat} 形式では対応していないため保存されませんでした。`, // TODO: translate
   areYouSureWantToDeleteFollowingMove: (n) => `將會刪除${n}手目以後的棋譜。請問您要繼續嗎？`,
   failedToOpenDirectory: (path) => `無法開啟檔案目錄：${path}`,
   unexpectedEventSenderPleaseReport(sender) {

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -183,6 +183,7 @@ export type Texts = {
   recordProperties: string;
   comments: string;
   commentsAndBookmarks: string;
+  branches: string;
   bookmark: string;
   bookmarkList: string;
   useBookmarkAsHeader: string;
@@ -427,6 +428,7 @@ export type Texts = {
   addNthEngine: (n: number) => string;
   copyOf: (name: string) => string;
   keepLatest: (n: number) => string;
+  followingDataNotSavedBecauseNotSupporetedBy: (fileFormat: string) => string;
   areYouSureWantToDeleteFollowingMove: (n: number) => string;
   failedToOpenDirectory: (path: string) => string;
   unexpectedEventSenderPleaseReport: (sender: string) => string;

--- a/src/renderer/helpers/record.ts
+++ b/src/renderer/helpers/record.ts
@@ -1,0 +1,58 @@
+import { RecordFileFormat } from "@/common/file";
+import { ImmutableRecord } from "@/common/shogi";
+
+export type RecordProperties = {
+  branch: boolean;
+  comment: boolean;
+  bookmark: boolean;
+  time: boolean;
+};
+
+export function detectUnsupportedRecordProperties(
+  record: ImmutableRecord,
+  fileType: RecordFileFormat,
+): RecordProperties {
+  const props: RecordProperties = {
+    branch: false,
+    comment: false,
+    bookmark: false,
+    time: false,
+  };
+  if (fileType === RecordFileFormat.KIF || fileType === RecordFileFormat.KIFU) {
+    return props;
+  }
+  record.forEach((node) => {
+    if (node.branch) {
+      props.branch = true;
+    }
+    if (node.comment) {
+      props.comment = true;
+    }
+    if (node.bookmark) {
+      props.bookmark = true;
+    }
+    if (node.elapsedMs) {
+      props.time = true;
+    }
+  });
+  switch (fileType) {
+    case RecordFileFormat.KI2:
+    case RecordFileFormat.KI2U:
+      props.branch = false;
+      props.comment = false;
+      props.bookmark = false;
+      break;
+    case RecordFileFormat.CSA:
+      props.comment = false;
+      props.time = false;
+      break;
+    case RecordFileFormat.SFEN:
+      break;
+    case RecordFileFormat.JKF:
+      props.branch = false;
+      props.comment = false;
+      props.time = false;
+      break;
+  }
+  return props;
+}

--- a/src/tests/renderer/helpers/record.spec.ts
+++ b/src/tests/renderer/helpers/record.spec.ts
@@ -1,0 +1,99 @@
+import { RecordFileFormat } from "@/common/file";
+import { Record, SpecialMoveType } from "@/common/shogi";
+import { detectUnsupportedRecordProperties } from "@/renderer/helpers/record";
+
+describe("helpers/record", () => {
+  it("detectUnsupportedRecordProperties", () => {
+    const record = new Record();
+    expect(detectUnsupportedRecordProperties(record, RecordFileFormat.KIF)).toStrictEqual({
+      branch: false,
+      comment: false,
+      bookmark: false,
+      time: false,
+    });
+    expect(detectUnsupportedRecordProperties(record, RecordFileFormat.KIFU)).toStrictEqual({
+      branch: false,
+      comment: false,
+      bookmark: false,
+      time: false,
+    });
+    expect(detectUnsupportedRecordProperties(record, RecordFileFormat.KI2)).toStrictEqual({
+      branch: false,
+      comment: false,
+      bookmark: false,
+      time: false,
+    });
+    expect(detectUnsupportedRecordProperties(record, RecordFileFormat.KI2U)).toStrictEqual({
+      branch: false,
+      comment: false,
+      bookmark: false,
+      time: false,
+    });
+    expect(detectUnsupportedRecordProperties(record, RecordFileFormat.CSA)).toStrictEqual({
+      branch: false,
+      comment: false,
+      bookmark: false,
+      time: false,
+    });
+    expect(detectUnsupportedRecordProperties(record, RecordFileFormat.SFEN)).toStrictEqual({
+      branch: false,
+      comment: false,
+      bookmark: false,
+      time: false,
+    });
+    expect(detectUnsupportedRecordProperties(record, RecordFileFormat.JKF)).toStrictEqual({
+      branch: false,
+      comment: false,
+      bookmark: false,
+      time: false,
+    });
+
+    record.append(SpecialMoveType.RESIGN);
+    record.append(SpecialMoveType.INTERRUPT);
+    record.first.comment = "foo";
+    record.first.bookmark = "bar";
+    record.current.setElapsedMs(123);
+    expect(detectUnsupportedRecordProperties(record, RecordFileFormat.KIF)).toStrictEqual({
+      branch: false,
+      comment: false,
+      bookmark: false,
+      time: false,
+    });
+    expect(detectUnsupportedRecordProperties(record, RecordFileFormat.KIFU)).toStrictEqual({
+      branch: false,
+      comment: false,
+      bookmark: false,
+      time: false,
+    });
+    expect(detectUnsupportedRecordProperties(record, RecordFileFormat.KI2)).toStrictEqual({
+      branch: false,
+      comment: false,
+      bookmark: false,
+      time: true,
+    });
+    expect(detectUnsupportedRecordProperties(record, RecordFileFormat.KI2U)).toStrictEqual({
+      branch: false,
+      comment: false,
+      bookmark: false,
+      time: true,
+    });
+    expect(detectUnsupportedRecordProperties(record, RecordFileFormat.CSA)).toStrictEqual({
+      branch: true,
+      comment: false,
+      bookmark: true,
+      time: false,
+    });
+    expect(detectUnsupportedRecordProperties(record, RecordFileFormat.SFEN)).toStrictEqual({
+      branch: true,
+      comment: true,
+      bookmark: true,
+      time: true,
+    });
+    expect(detectUnsupportedRecordProperties(record, RecordFileFormat.JKF)).toStrictEqual({
+      branch: false,
+      comment: false,
+      bookmark: true,
+      time: false,
+    });
+  });
+});


### PR DESCRIPTION
# 説明 / Description

#602 

![スクリーンショット (142)](https://github.com/sunfish-shogi/electron-shogi/assets/6257462/53a96354-fe8e-4e77-9c76-0051c9d65ba3)

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [x] i18n
