### PR TITLE
Fix record format detection

### DIFF
--- a/src/common/shogi/detect.ts
+++ b/src/common/shogi/detect.ts
@@ -27,7 +27,7 @@ export function detectRecordFormat(data: string): RecordFormatType {
   }
 
   // JKF
-  if (data.match(/^ *{/) && data.match(/} *$/)) {
+  if (data.match(/^[\s\r\n]*{/) && data.match(/}[\s\r\n]*$/)) {
     return RecordFormatType.JKF;
   }
 

--- a/src/tests/common/shogi/detect.spec.ts
+++ b/src/tests/common/shogi/detect.spec.ts
@@ -110,7 +110,8 @@ T0
   });
 
   it("jkf", () => {
-    const data = `{ "header": {}, "moves": [] }`;
-    expect(detectRecordFormat(data)).toBe(RecordFormatType.JKF);
+    expect(detectRecordFormat(`{ "header": {}, "moves": [] }`)).toBe(RecordFormatType.JKF);
+    expect(detectRecordFormat(` { "header": {}, "moves": [] } `)).toBe(RecordFormatType.JKF);
+    expect(detectRecordFormat(`\n{ "header": {}, "moves": [] }\n`)).toBe(RecordFormatType.JKF);
   });
 });


### PR DESCRIPTION
# 説明 / Description

棋譜フォーマット検出において、 JKF と判断する条件を修正。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [ ] i18n
