### PR TITLE
Fix app setting file I/O confliction

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -11,7 +11,7 @@ import {
   setInitialFilePath,
   setup,
 } from "@/background/ipc";
-import { loadAppSettingSync, loadWindowSetting, saveWindowSetting } from "@/background/settings";
+import { loadAppSettingOnce, loadWindowSetting, saveWindowSetting } from "@/background/settings";
 import { buildWindowSetting } from "@/common/settings/window";
 import { getAppLogger, shutdownLoggers } from "@/background/log";
 import { quitAll as usiQuitAll } from "@/background/usi";
@@ -38,7 +38,7 @@ protocol.registerSchemesAsPrivileged([
   { scheme: "app", privileges: { secure: true, standard: true } },
 ]);
 
-setLanguage(loadAppSettingSync().language);
+setLanguage(loadAppSettingOnce().language);
 
 function createWindow() {
   let setting = loadWindowSetting();

--- a/src/background/log.ts
+++ b/src/background/log.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import { shell } from "electron";
 import log4js from "log4js";
-import { loadAppSettingSync } from "@/background/settings";
+import { loadAppSettingOnce } from "@/background/settings";
 import { getDateTimeString } from "@/common/helpers/datetime";
 import { getAppPath, isTest } from "./environment";
 import { AppSetting } from "@/common/settings/app";
@@ -58,7 +58,7 @@ function getLogger(type: LogType): log4js.Logger {
     return loggers[type];
   }
   if (!config.appenders[type]) {
-    const appSetting = loadAppSettingSync();
+    const appSetting = loadAppSettingOnce();
     config.appenders[type] = { type: "file", filename: getFilePath(type) };
     config.categories[type] = {
       appenders: isLogEnabled(type, appSetting) ? [type] : !isTest() ? ["stdout"] : ["recording"],

--- a/src/background/settings.ts
+++ b/src/background/settings.ts
@@ -108,11 +108,20 @@ function loadAppSettingFromMemory(json: string): AppSetting {
   });
 }
 
-export function loadAppSettingSync(): AppSetting {
+function loadAppSettingSync(): AppSetting {
   if (!fs.existsSync(appSettingPath)) {
     return getDefaultAppSetting();
   }
   return loadAppSettingFromMemory(fs.readFileSync(appSettingPath, "utf8"));
+}
+
+let appSettingCache: AppSetting;
+
+export function loadAppSettingOnce(): AppSetting {
+  if (!appSettingCache) {
+    appSettingCache = loadAppSettingSync();
+  }
+  return appSettingCache;
 }
 
 export async function loadAppSetting(): Promise<AppSetting> {


### PR DESCRIPTION
# 説明 / Description

アプリ設定のファイル I/O が Sync 関数と Async 関数 で競合してしまい、読み取ったデータが 0 バイトになることがある。
具体的には起動直後にエンジン追加をしようとすると、ファイル選択ダイアログを閉じたときの書き込みと、 Logger を初期化するための読み込みが衝突する。
readFileSync を使うのは起動直後だけにして、値をキャッシュしておくように修正する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
