### PR TITLE
思考タブや読み筋タブの評価値の表示を修正

### DIFF
--- a/src/renderer/view/tab/EngineAnalyticsElement.vue
+++ b/src/renderer/view/tab/EngineAnalyticsElement.vue
@@ -60,9 +60,9 @@
           </div>
           <div class="list-column score">
             {{
-              iterate.scoreMate
+              iterate.scoreMate !== undefined
                 ? getDisplayScore(iterate.scoreMate, iterate.color, evaluationViewFrom)
-                : iterate.score
+                : iterate.score !== undefined
                 ? getDisplayScore(iterate.score, iterate.color, evaluationViewFrom)
                 : ""
             }}


### PR DESCRIPTION
# 説明 / Description

#631 

思考タブや読み筋タブで、評価値がちょうど 0 の場合に "0" ではなく空欄になっていた問題を修正。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
