### PR TITLE
棋譜の自動保存後に評価値の更新が入ってしまう問題の修正

### DIFF
--- a/src/renderer/store/game.ts
+++ b/src/renderer/store/game.ts
@@ -167,10 +167,10 @@ export class GameManager {
     // プレイヤーを初期化する。
     try {
       this.blackPlayer = await this.playerBuilder.build(this.setting.black, (info) =>
-        this.recordManager.updateSearchInfo(SearchInfoSenderType.OPPONENT, info),
+        this.updateSearchInfo(SearchInfoSenderType.OPPONENT, info),
       );
       this.whitePlayer = await this.playerBuilder.build(this.setting.white, (info) =>
-        this.recordManager.updateSearchInfo(SearchInfoSenderType.OPPONENT, info),
+        this.updateSearchInfo(SearchInfoSenderType.OPPONENT, info),
       );
       await this.nextGame();
     } catch (e) {
@@ -345,7 +345,7 @@ export class GameManager {
     });
     // 評価値を記録する。
     if (info) {
-      this.recordManager.updateSearchInfo(SearchInfoSenderType.PLAYER, info);
+      this.updateSearchInfo(SearchInfoSenderType.PLAYER, info);
     }
     // コメントを追加する。
     if (info && this.setting.enableComment) {
@@ -471,6 +471,13 @@ export class GameManager {
         this.onError(new Error(`GameManager#endGame: ${t.errorOccuredWhileEndingGame}: ${e}`));
         this.state = GameState.PENDING;
       });
+  }
+
+  private updateSearchInfo(senderType: SearchInfoSenderType, info: SearchInfo): void {
+    if (this.state !== GameState.ACTIVE) {
+      return;
+    }
+    this.recordManager.updateSearchInfo(senderType, info);
   }
 
   private addGameResults(color: Color, specialMoveType: SpecialMoveType): void {


### PR DESCRIPTION
# 説明 / Description

#627

棋譜の自動保存が実行された直後にエンジンから送られた評価値が反映されて、棋譜が未保存ステータスになる問題を修正する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
