### PR TITLE
脆弱性報告に伴うライブラリのパッチアップデート

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6296,9 +6296,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-26.2.0.tgz",
-      "integrity": "sha512-H6Z0sYTtLcybHCQT1yti/8BK+vN5/ZfoekKcdrfZMh5mVf2Z7psFVs6nBhXPzIOyRE/gdb6NcOppnUsGc3NJVQ==",
+      "version": "26.2.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-26.2.1.tgz",
+      "integrity": "sha512-SNT24Cf/wRvfcFZQoERXjzswUlg5ouqhIuA2t9x2L7VdTn+2Jbs0QXRtOfzcnOV/raVMz3e8ICyaU2GGeciKLg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {


### PR DESCRIPTION
# 説明 / Description

libwebp で OOB の脆弱性が報告されているので一応バージョンを上げておく。
ただ、 Electron 将棋の場合にこの脆弱性が問題になることは無いと思われる。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
