### PR TITLE
検討機能を利用するだけで未保存ラベルが表示される問題を修正

### DIFF
--- a/src/renderer/store/record.ts
+++ b/src/renderer/store/record.ts
@@ -520,7 +520,6 @@ export class RecordManager {
         break;
     }
     this._record.current.customData = data;
-    this._unsaved = true;
   }
 
   appendMove(params: AppendMoveParams): boolean {


### PR DESCRIPTION
# 説明 / Description

#637 

検討機能を使用すると、棋譜が保存済みであっても未保存ラベルが表示されていた。
検討の評価値は棋譜ファイルに書き出す情報に含めないのだが、エンジンから評価値を受け取ったときに未保存ステータスにするように実装されていた。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
