### PR TITLE
hide clock when not playing game

### DIFF
--- a/src/renderer/view/dialog/PositionImageExportDialog.vue
+++ b/src/renderer/view/dialog/PositionImageExportDialog.vue
@@ -31,6 +31,7 @@
               :position="record.position"
               :last-move="lastMove"
               :flip="appSetting.boardFlipping"
+              :hide-clock="true"
               :black-player-name="blackPlayerName"
               :white-player-name="whitePlayerName"
             />

--- a/src/renderer/view/main/BoardPane.vue
+++ b/src/renderer/view/main/BoardPane.vue
@@ -14,6 +14,7 @@
       :position="store.record.position"
       :last-move="lastMove"
       :flip="appSetting.boardFlipping"
+      :hide-clock="store.appState !== AppState.GAME && store.appState !== AppState.CSA_GAME"
       :allow-move="store.isMovableByUser"
       :allow-edit="store.appState === AppState.POSITION_EDITING"
       :black-player-name="blackPlayerName"

--- a/src/renderer/view/primitive/BoardLayout.ts
+++ b/src/renderer/view/primitive/BoardLayout.ts
@@ -104,10 +104,12 @@ const layoutTemplate = {
     black: {
       x: 1184,
       y: 425,
+      y2: 490,
     },
     white: {
       x: 0,
-      y: 492,
+      y: 495,
+      y2: 430,
     },
     width: 288,
     height: 45,
@@ -117,10 +119,12 @@ const layoutTemplate = {
     black: {
       x: 1184,
       y: 480,
+      y2: 545,
     },
     white: {
       x: 0,
       y: 370,
+      y2: 370,
     },
     width: 288,
     height: 45,
@@ -384,8 +388,8 @@ export type FullLayout = {
   turn: TurnLayout;
   blackPlayerName: PlayerNameLayout;
   whitePlayerName: PlayerNameLayout;
-  blackClock: ClockLayout;
-  whiteClock: ClockLayout;
+  blackClock?: ClockLayout;
+  whiteClock?: ClockLayout;
   control: ControlLayout;
 };
 
@@ -416,6 +420,7 @@ export type LayoutConfig = {
   boardLabelType: BoardLabelType;
   upperSizeLimit: RectSize;
   flip?: boolean;
+  hideClock?: boolean;
 };
 
 export default class LayoutBuilder {
@@ -774,10 +779,13 @@ export default class LayoutBuilder {
       const color = position.color;
       const displayColor = config.flip ? reverseColor(color) : color;
       const borderWidth = 2;
+      const template = layoutTemplate.turn[displayColor];
+      const x = template.x;
+      const y = config.hideClock ? template.y2 : template.y;
       return {
         style: {
-          left: layoutTemplate.turn[displayColor].x * ratio - borderWidth + "px",
-          top: layoutTemplate.turn[displayColor].y * ratio - borderWidth + "px",
+          left: x * ratio - borderWidth + "px",
+          top: y * ratio - borderWidth + "px",
           width: layoutTemplate.turn.width * ratio - borderWidth + "px",
           height: layoutTemplate.turn.height * ratio - borderWidth + "px",
           "font-size": layoutTemplate.turn.fontSize * ratio + "px",
@@ -790,10 +798,13 @@ export default class LayoutBuilder {
 
     const buildPlayerNameLayout = (color: Color): PlayerNameLayout => {
       const displayColor = config.flip ? reverseColor(color) : color;
+      const template = layoutTemplate.playerName[displayColor];
+      const x = template.x;
+      const y = config.hideClock ? template.y2 : template.y;
       return {
         style: {
-          left: layoutTemplate.playerName[displayColor].x * ratio + "px",
-          top: layoutTemplate.playerName[displayColor].y * ratio + "px",
+          left: x * ratio + "px",
+          top: y * ratio + "px",
           width: layoutTemplate.playerName.width * ratio + "px",
           height: layoutTemplate.playerName.height * ratio + "px",
           "font-size": layoutTemplate.playerName.fontSize * ratio + "px",
@@ -848,8 +859,8 @@ export default class LayoutBuilder {
     const turnLayout = buildTurnLayout();
     const blackPlayerNameLayout = buildPlayerNameLayout(Color.BLACK);
     const whitePlayerNameLayout = buildPlayerNameLayout(Color.WHITE);
-    const blackClockLayout = buildClockLayout(Color.BLACK);
-    const whiteClockLayout = buildClockLayout(Color.WHITE);
+    const blackClockLayout = config.hideClock ? undefined : buildClockLayout(Color.BLACK);
+    const whiteClockLayout = config.hideClock ? undefined : buildClockLayout(Color.WHITE);
     const controlLayout = buildControlLayout();
     return {
       frame: frameLayout,

--- a/src/renderer/view/primitive/BoardView.vue
+++ b/src/renderer/view/primitive/BoardView.vue
@@ -14,7 +14,12 @@
       >
         <span class="player-name-text">☗{{ blackPlayerName }}</span>
       </div>
-      <div class="clock" :class="blackPlayerTimeSeverity" :style="layout.blackClock.style">
+      <div
+        v-if="layout.blackClock"
+        class="clock"
+        :class="blackPlayerTimeSeverity"
+        :style="layout.blackClock.style"
+      >
         <span class="clock-text">{{ blackPlayerTimeText }}</span>
       </div>
       <div
@@ -24,7 +29,12 @@
       >
         <span class="player-name-text">☖{{ whitePlayerName }}</span>
       </div>
-      <div class="clock" :class="whitePlayerTimeSeverity" :style="layout.whiteClock.style">
+      <div
+        v-if="layout.whiteClock"
+        class="clock"
+        :class="whitePlayerTimeSeverity"
+        :style="layout.whiteClock.style"
+      >
         <span class="clock-text">{{ whitePlayerTimeText }}</span>
       </div>
       <div v-for="square in layout.square" :key="square.id" :style="square.backgroundStyle"></div>
@@ -189,6 +199,11 @@ const props = defineProps({
   flip: {
     type: Boolean,
     required: false,
+  },
+  hideClock: {
+    type: Boolean,
+    required: false,
+    default: false,
   },
   allowEdit: {
     type: Boolean,
@@ -387,6 +402,7 @@ const layout = computed(() => {
       boardLabelType: props.boardLabelType,
       upperSizeLimit: props.maxSize,
       flip: props.flip,
+      hideClock: props.hideClock,
     },
     props.position,
     props.lastMove,


### PR DESCRIPTION
# 説明 / Description

対局以外では常に残り時間の欄に `0:00:00` と表示されていて、情報としての意味はない。
特に局面図書き出すときや画面キャプチャをとる場合に邪魔なので、対局中以外は欄自体を表示しないようにする。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
