### PR TITLE
古いバックアップファイルが削除されずに残る不具合を修正

### DIFF
--- a/src/background/history.ts
+++ b/src/background/history.ts
@@ -106,9 +106,6 @@ export function saveBackup(kif: string): Promise<void> {
       class: HistoryClass.BACKUP,
       backupFileName: fileName,
     });
-    while (history.entries.length > historyMaxLength) {
-      history.entries.shift();
-    }
     trancate(history);
     await saveHistories(history);
   });


### PR DESCRIPTION
# 説明 / Description

新しいバックアップファイルを作った際に、最大数を超えて古いファイルを消す処理が実行されていなかった。

古い履歴の削除は `trancate` 関数に一任するようにしたが、開発中の古いコード片が残っていてファイルの実態を消す前に履歴から消えていた。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
