### PR TITLE
ラベル機能に伴うエンジン管理の不具合を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-shogi",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Shogi Frontend Application",
   "author": "Kubo Ryosuke",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-shogi",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Shogi Frontend Application",
   "author": "Kubo Ryosuke",
   "license": "MIT",

--- a/src/common/settings/usi.ts
+++ b/src/common/settings/usi.ts
@@ -99,6 +99,7 @@ export function mergeUSIEngineSetting(engine: USIEngineSetting, local: USIEngine
     }
     engine.options[name].value = local.options[name].value;
   });
+  engine.labels = local.labels;
 }
 
 export interface ImmutableUSIEngineSettings {

--- a/src/common/settings/usi.ts
+++ b/src/common/settings/usi.ts
@@ -108,6 +108,7 @@ export interface ImmutableUSIEngineSettings {
   get json(): string;
   get jsonWithIndent(): string;
   getClone(): USIEngineSettings;
+  filterByLabel(label: USIEngineLabel): USIEngineSettings;
 }
 
 export class USIEngineSettings {

--- a/src/renderer/view/dialog/AnalysisDialog.vue
+++ b/src/renderer/view/dialog/AnalysisDialog.vue
@@ -7,6 +7,7 @@
         <PlayerSelector
           :player-uri="engineURI"
           :engine-settings="engineSettings"
+          :filter-label="USIEngineLabel.RESEARCH"
           :display-thread-state="true"
           :display-multi-pv-state="true"
           @update-engine-setting="onUpdatePlayerSetting"
@@ -126,9 +127,7 @@ onMounted(async () => {
   installHotKeyForDialog(dialog.value);
   try {
     const analysisSetting = await api.loadAnalysisSetting();
-    engineSettings.value = (await api.loadUSIEngineSetting()).filterByLabel(
-      USIEngineLabel.RESEARCH,
-    );
+    engineSettings.value = await api.loadUSIEngineSetting();
     engineURI.value = analysisSetting.usi?.uri || "";
     enableStartNumber.value = analysisSetting.startCriteria.enableNumber;
     startNumber.value.value = analysisSetting.startCriteria.number;

--- a/src/renderer/view/dialog/CSAGameDialog.vue
+++ b/src/renderer/view/dialog/CSAGameDialog.vue
@@ -16,6 +16,7 @@
             :player-uri="playerURI"
             :contains-human="true"
             :engine-settings="engineSettings"
+            :filter-label="USIEngineLabel.GAME"
             :display-ponder-state="true"
             :display-thread-state="true"
             :display-multi-pv-state="true"
@@ -234,7 +235,7 @@ onMounted(async () => {
   try {
     isEncryptionAvailable.value = await api.isEncryptionAvailable();
     history.value = await api.loadCSAGameSettingHistory();
-    engineSettings.value = (await api.loadUSIEngineSetting()).filterByLabel(USIEngineLabel.GAME);
+    engineSettings.value = await api.loadUSIEngineSetting();
     showModalDialog(dialog.value);
     installHotKeyForDialog(dialog.value);
     defaultValueLoaded = true;

--- a/src/renderer/view/dialog/GameDialog.vue
+++ b/src/renderer/view/dialog/GameDialog.vue
@@ -10,6 +10,7 @@
               :player-uri="blackPlayerURI"
               :contains-human="true"
               :engine-settings="engineSettings"
+              :filter-label="USIEngineLabel.GAME"
               :display-ponder-state="true"
               :display-thread-state="true"
               :display-multi-pv-state="true"
@@ -24,6 +25,7 @@
               :player-uri="whitePlayerURI"
               :contains-human="true"
               :engine-settings="engineSettings"
+              :filter-label="USIEngineLabel.GAME"
               :display-ponder-state="true"
               :display-thread-state="true"
               :display-multi-pv-state="true"
@@ -267,7 +269,7 @@ store.retainBussyState();
 onMounted(async () => {
   try {
     gameSetting.value = await api.loadGameSetting();
-    engineSettings.value = (await api.loadUSIEngineSetting()).filterByLabel(USIEngineLabel.GAME);
+    engineSettings.value = await api.loadUSIEngineSetting();
     blackPlayerURI.value = gameSetting.value.black.uri;
     whitePlayerURI.value = gameSetting.value.white.uri;
     showModalDialog(dialog.value);

--- a/src/renderer/view/dialog/MateSearchDialog.vue
+++ b/src/renderer/view/dialog/MateSearchDialog.vue
@@ -6,6 +6,7 @@
         <PlayerSelector
           :player-uri="engineURI"
           :engine-settings="engineSettings"
+          :filter-label="USIEngineLabel.MATE"
           :display-thread-state="true"
           :display-multi-pv-state="false"
           @update-engine-setting="
@@ -53,7 +54,7 @@ onMounted(async () => {
   installHotKeyForDialog(dialog.value);
   try {
     const mateSearchSetting = await api.loadMateSearchSetting();
-    engineSettings.value = (await api.loadUSIEngineSetting()).filterByLabel(USIEngineLabel.MATE);
+    engineSettings.value = await api.loadUSIEngineSetting();
     engineURI.value = mateSearchSetting.usi?.uri || "";
   } catch (e) {
     store.pushError(e);

--- a/src/renderer/view/dialog/PlayerSelector.vue
+++ b/src/renderer/view/dialog/PlayerSelector.vue
@@ -9,7 +9,11 @@
         @change="onPlayerChange"
       >
         <option v-if="containsHuman" :value="uri.ES_HUMAN">人</option>
-        <option v-for="engine in engineSettings.engineList" :key="engine.uri" :value="engine.uri">
+        <option
+          v-for="engine in filteredEngineSettings.engineList"
+          :key="engine.uri"
+          :value="engine.uri"
+        >
           {{ engine.name }}
         </option>
       </select>
@@ -57,6 +61,7 @@ import {
   NumberOfThreads,
   MultiPV,
   USIEngineSettings,
+  USIEngineLabel,
 } from "@/common/settings/usi";
 import { useStore } from "@/renderer/store";
 import api from "@/renderer/ipc/api";
@@ -72,6 +77,10 @@ const props = defineProps({
   },
   engineSettings: {
     type: Object as PropType<ImmutableUSIEngineSettings>,
+    required: true,
+  },
+  filterLabel: {
+    type: String as PropType<USIEngineLabel>,
     required: true,
   },
   displayPonderState: {
@@ -97,11 +106,15 @@ const store = useStore();
 const playerSelect = ref();
 const engineSettingDialog = ref(null as USIEngineSetting | null);
 
+const filteredEngineSettings = computed(() => {
+  return props.engineSettings.filterByLabel(props.filterLabel);
+});
+
 const ponderState = computed(() => {
   if (!uri.isUSIEngine(props.playerUri)) {
     return null;
   }
-  const engine = props.engineSettings.getEngine(props.playerUri);
+  const engine = filteredEngineSettings.value.getEngine(props.playerUri);
   return engine && getUSIEngineOptionCurrentValue(engine.options[USIPonder]) === "true"
     ? "ON"
     : "OFF";
@@ -111,7 +124,7 @@ const threadState = computed(() => {
   if (!uri.isUSIEngine(props.playerUri)) {
     return null;
   }
-  const engine = props.engineSettings.getEngine(props.playerUri);
+  const engine = filteredEngineSettings.value.getEngine(props.playerUri);
   if (!engine) {
     return null;
   }
@@ -125,7 +138,7 @@ const multiPVState = computed(() => {
   if (!uri.isUSIEngine(props.playerUri)) {
     return null;
   }
-  const engine = props.engineSettings.getEngine(props.playerUri);
+  const engine = filteredEngineSettings.value.getEngine(props.playerUri);
   if (!engine) {
     return null;
   }
@@ -141,7 +154,7 @@ const isPlayerSettingEnabled = computed(() => {
 
 const openPlayerSetting = () => {
   if (uri.isUSIEngine(props.playerUri)) {
-    const engine = props.engineSettings.getEngine(props.playerUri);
+    const engine = filteredEngineSettings.value.getEngine(props.playerUri);
     if (!engine) {
       store.pushError("利用可能なエンジンが選択されていません。");
       return;

--- a/src/renderer/view/dialog/ResearchDialog.vue
+++ b/src/renderer/view/dialog/ResearchDialog.vue
@@ -6,6 +6,7 @@
         <PlayerSelector
           :player-uri="engineURI"
           :engine-settings="engineSettings"
+          :filter-label="USIEngineLabel.RESEARCH"
           :display-thread-state="true"
           :display-multi-pv-state="true"
           @update-engine-setting="onUpdatePlayerSetting"
@@ -20,6 +21,7 @@
         <PlayerSelector
           :player-uri="uri"
           :engine-settings="engineSettings"
+          :filter-label="USIEngineLabel.RESEARCH"
           :display-thread-state="true"
           :display-multi-pv-state="true"
           @update-engine-setting="onUpdatePlayerSetting"
@@ -106,9 +108,7 @@ onMounted(async () => {
   installHotKeyForDialog(dialog.value);
   try {
     researchSetting.value = await api.loadResearchSetting();
-    engineSettings.value = (await api.loadUSIEngineSetting()).filterByLabel(
-      USIEngineLabel.RESEARCH,
-    );
+    engineSettings.value = await api.loadUSIEngineSetting();
     engineURI.value = researchSetting.value.usi?.uri || "";
     secondaryEngineURIs.value =
       researchSetting.value.secondaries?.map((setting) => setting.usi?.uri || "") || [];

--- a/src/tests/common/settings/usi.spec.ts
+++ b/src/tests/common/settings/usi.spec.ts
@@ -160,7 +160,10 @@ describe("settings/usi", () => {
           value: 15,
         },
       },
-      labels: {},
+      labels: {
+        game: true,
+        mate: false,
+      },
     };
     mergeUSIEngineSetting(lhs, rhs);
     expect(lhs).toStrictEqual({
@@ -181,7 +184,10 @@ describe("settings/usi", () => {
           value: 15,
         },
       },
-      labels: {},
+      labels: {
+        game: true,
+        mate: false,
+      },
     });
   });
 


### PR DESCRIPTION
# 説明 / Description

エンジンのラベル付け（用途選択）機能に関連する以下の不具合を修正する。

- 「エンジン管理」以外の「対局」や「検討」「解析」「詰み探索」のダイアログ上からエンジンオプションを保存すると、そのダイアログで表示されていなかったエンジンが登録解除される。
- エンジンオプションを保存するとラベルが初期化される（全てチェックした状態に戻る）。こちらはどの画面を経由した場合も起こる。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [ ] i18n
