### PR TITLE
Add sub items into debug menu

### DIFF
--- a/src/background/history.ts
+++ b/src/background/history.ts
@@ -9,12 +9,17 @@ import {
 } from "@/common/history";
 import { getAppLogger } from "./log";
 import AsyncLock from "async-lock";
+import { shell } from "electron";
 
 const historyMaxLength = 20;
 
 const userDir = getAppPath("userData");
 const historyPath = path.join(userDir, "record_file_history.json");
 const backupDir = path.join(userDir, "backup/kifu");
+
+export function openBackupDirectory(): void {
+  shell.openPath(backupDir);
+}
 
 const lock = new AsyncLock();
 

--- a/src/background/image/cache.ts
+++ b/src/background/image/cache.ts
@@ -1,5 +1,10 @@
 import path from "path";
 import { getAppPath, getPortableExeDir } from "@/background/environment";
+import { shell } from "electron";
 
 const userDataRoot = getPortableExeDir() || getAppPath("userData");
 export const imageCacheDir = path.join(userDataRoot, "image_cache");
+
+export function openCacheDirectory() {
+  shell.openPath(imageCacheDir);
+}

--- a/src/background/menu.ts
+++ b/src/background/menu.ts
@@ -9,6 +9,8 @@ import { checkLatestVersion, openHowToUse, openWebSite } from "./help";
 import { t } from "@/common/i18n";
 import { InitialPositionSFEN } from "@/common/shogi";
 import { getAppPath } from "./environment";
+import { openBackupDirectory } from "./history";
+import { openCacheDirectory } from "./image/cache";
 
 const isMac = process.platform === "darwin";
 
@@ -326,6 +328,14 @@ function createMenuTemplate() {
         {
           label: t.openLogDirectory,
           click: openLogsDirectory,
+        },
+        {
+          label: t.openBackupDirectory,
+          click: openBackupDirectory,
+        },
+        {
+          label: t.openCacheDirectory,
+          click: openCacheDirectory,
         },
       ],
     },

--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -48,6 +48,8 @@ export const en: Texts = {
   openAppDirectory: "Open App Directory",
   openSettingDirectory: "Open Setting Directory",
   openLogDirectory: "Open Log Directory",
+  openBackupDirectory: "Open Backup Directory",
+  openCacheDirectory: "Open Cache Directory",
   help: "Help",
   openWebSite: "Open Web Site",
   howToUse: "How to Use",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -47,6 +47,8 @@ export const ja: Texts = {
   openAppDirectory: "アプリのフォルダを開く",
   openSettingDirectory: "設定ファイルのフォルダを開く",
   openLogDirectory: "ログファイルのフォルダを開く",
+  openBackupDirectory: "バックアップのフォルダを開く",
+  openCacheDirectory: "キャッシュのフォルダを開く",
   help: "ヘルプ",
   openWebSite: "Webサイトを開く",
   howToUse: "使い方を開く",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -47,6 +47,8 @@ export const zh_tw: Texts = {
   openAppDirectory: "顯示本程式所在資料夾",
   openSettingDirectory: "開啟設定檔案所在資料夾",
   openLogDirectory: "開啟紀錄檔(log)所在資料夾",
+  openBackupDirectory: "バックアップのフォルダを開く", // TODO: translate
+  openCacheDirectory: "キャッシュのフォルダを開く", // TODO: translate
   help: "協助",
   openWebSite: "官方網站",
   howToUse: "使用教學",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -45,6 +45,8 @@ export type Texts = {
   openAppDirectory: string;
   openSettingDirectory: string;
   openLogDirectory: string;
+  openBackupDirectory: string;
+  openCacheDirectory: string;
   help: string;
   openWebSite: string;
   howToUse: string;


### PR DESCRIPTION
# 説明 / Description

デバッグメニューに「キャッシュのフォルダを開く」と「バックアップのフォルダを開く」を追加。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
