### PR TITLE
Set no-console rule as error

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -13,8 +13,8 @@ module.exports = {
     "prettier",
   ],
   rules: {
-    "no-console": process.env.NODE_ENV === "production" ? "warn" : "off",
-    "no-debugger": process.env.NODE_ENV === "production" ? "warn" : "off",
+    "no-console": "error",
+    "no-debugger": "error",
     "no-irregular-whitespace": "off",
     "vue/multi-word-component-names": "off",
   },

--- a/scripts/publish-release.ts
+++ b/scripts/publish-release.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import fs from "node:fs";
 import { promises as readline } from "node:readline";
 import { Releases } from "../src/background/version/types";

--- a/src/background/log.ts
+++ b/src/background/log.ts
@@ -84,6 +84,7 @@ export function getCSALogger(): log4js.Logger {
 
 export function shutdownLoggers(): void {
   log4js.shutdown((e) => {
+    // eslint-disable-next-line no-console
     console.error("failed to shutdown loggers:", e);
   });
 }

--- a/src/renderer/ipc/web.ts
+++ b/src/renderer/ipc/web.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { defaultAnalysisSetting } from "@/common/settings/analysis";
 import { defaultAppSetting } from "@/common/settings/app";
 import { defaultGameSetting } from "@/common/settings/game";


### PR DESCRIPTION
# 説明 / Description

#666 

eslint の no-console ルールをエラーレベルに設定する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
