### PR TITLE
起動時引数のサポートを強化

### DIFF
--- a/src/background/args.ts
+++ b/src/background/args.ts
@@ -1,0 +1,35 @@
+import { InitialRecordFileRequest } from "@/common/file";
+import { getAppLogger } from "./log";
+import { isSupportedRecordFilePath } from "./extensions";
+
+let initialFilePath = "";
+
+export function setInitialFilePath(path: string): void {
+  initialFilePath = path;
+}
+
+export function fetchInitialRecordFileRequest(): InitialRecordFileRequest {
+  // macOS
+  if (isSupportedRecordFilePath(initialFilePath)) {
+    getAppLogger().debug(`record path from open-file event: ${initialFilePath}`);
+    return { path: initialFilePath };
+  }
+
+  let path = null;
+  let ply = undefined;
+  // Option:
+  //   ShogiGUI/KifuExplorer style:
+  //     -n <ply>
+  //   KifuBase style:
+  //     +<ply>
+  for (const arg of process.argv) {
+    if (isSupportedRecordFilePath(arg)) {
+      path = arg;
+    } else if (!isNaN(Number(arg))) {
+      ply = Number(arg);
+    } else if (arg.match(/^\+\d+$/)) {
+      ply = Number(arg.substring(1));
+    }
+  }
+  return path ? { path, ply } : null;
+}

--- a/src/background/extensions.ts
+++ b/src/background/extensions.ts
@@ -1,0 +1,15 @@
+/**
+ * ファイルパスの拡張子が対応している棋譜ファイルかどうかを判定します。
+ * 一括変換でしか対応していない .sfen は含めません。
+ */
+export function isSupportedRecordFilePath(path: string) {
+  const lowerCasePath = path.toLowerCase();
+  return (
+    lowerCasePath.endsWith(".kif") ||
+    lowerCasePath.endsWith(".kifu") ||
+    lowerCasePath.endsWith(".ki2") ||
+    lowerCasePath.endsWith(".ki2u") ||
+    lowerCasePath.endsWith(".csa") ||
+    lowerCasePath.endsWith(".jkf")
+  );
+}

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -2,15 +2,7 @@
 
 import path from "node:path";
 import { app, protocol, BrowserWindow, session } from "electron";
-import {
-  getAppState,
-  isClosable,
-  onClose,
-  openRecord,
-  sendError,
-  setInitialFilePath,
-  setup,
-} from "@/background/ipc";
+import { getAppState, isClosable, onClose, openRecord, sendError, setup } from "@/background/ipc";
 import { loadAppSettingOnce, loadWindowSetting, saveWindowSetting } from "@/background/settings";
 import { buildWindowSetting } from "@/common/settings/window";
 import { getAppLogger, shutdownLoggers } from "@/background/log";
@@ -27,6 +19,7 @@ import {
 } from "@/background/environment";
 import { setLanguage, t } from "@/common/i18n";
 import { checkUpdates } from "./version/check";
+import { setInitialFilePath } from "./args";
 
 getAppLogger().info(
   "start main process: %s %s %d",

--- a/src/common/file.ts
+++ b/src/common/file.ts
@@ -108,3 +108,8 @@ export function exportRecordAsBuffer(
   }
   return { data, garbled };
 }
+
+export type InitialRecordFileRequest = {
+  path: string;
+  ply?: number;
+} | null;

--- a/src/common/ipc/channel.ts
+++ b/src/common/ipc/channel.ts
@@ -1,5 +1,5 @@
 export enum Background {
-  GET_RECORD_PATH_FROM_PROC_ARG = "getRecordPathFromProcArg",
+  FETCH_INITIAL_RECORD_FILE_REQUEST = "fetchInitialRecordFileRequest",
   UPDATE_APP_STATE = "updateAppState",
   OPEN_EXPLORER = "openExplorer",
   SHOW_OPEN_RECORD_DIALOG = "showOpenRecordDialog",

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -59,10 +59,12 @@ Promise.allSettled([
       store.pushError(new Error("アプリ設定の読み込み中にエラーが発生しました: " + e));
     }),
   api
-    .getRecordPathFromProcArg()
-    .then((path) => {
-      if (path) {
-        store.openRecord(path);
+    .fetchInitialRecordFileRequest()
+    .then((request) => {
+      if (request) {
+        store.openRecord(request.path, {
+          ply: request.ply,
+        });
       }
     })
     .catch((e) => {

--- a/src/renderer/ipc/api.ts
+++ b/src/renderer/ipc/api.ts
@@ -15,13 +15,14 @@ import { MateSearchSetting } from "@/common/settings/mate";
 import { BatchConversionSetting } from "@/common/settings/conversion";
 import { BatchConversionResult } from "@/common/conversion";
 import { RecordFileHistory } from "@/common/history";
+import { InitialRecordFileRequest } from "@/common/file";
 
 type AppInfo = {
   appVersion?: string;
 };
 
 export interface Bridge {
-  getRecordPathFromProcArg(): Promise<string>;
+  fetchInitialRecordFileRequest(): Promise<string>;
   updateAppState(appState: AppState, bussy: boolean): void;
   openExplorer(path: string): void;
   showOpenRecordDialog(): Promise<string>;
@@ -118,7 +119,7 @@ export interface Bridge {
 }
 
 export interface API {
-  getRecordPathFromProcArg(): Promise<string>;
+  fetchInitialRecordFileRequest(): Promise<InitialRecordFileRequest>;
   updateAppState(appState: AppState, bussy: boolean): void;
   openExplorer(path: string): void;
   showOpenRecordDialog(): Promise<string>;
@@ -206,6 +207,9 @@ export const bridge: Bridge = getWindowObject().electronShogiAPI || webAPI;
 
 const api: API = {
   ...bridge,
+  async fetchInitialRecordFileRequest(): Promise<InitialRecordFileRequest> {
+    return JSON.parse(await bridge.fetchInitialRecordFileRequest());
+  },
   exportCaptureAsPNG(rect: Rect): Promise<void> {
     return bridge.exportCaptureAsPNG(rect.json);
   },

--- a/src/renderer/ipc/preload.ts
+++ b/src/renderer/ipc/preload.ts
@@ -14,8 +14,8 @@ const api: Bridge = {
   //   ライブラリやセキュアなオブジェクトを直接公開しないでください。
   //   必ず関数でラップして、必要最小限の参照だけをレンダラーに公開してください。
   //   See https://www.electronjs.org/docs/latest/tutorial/context-isolation#security-considerations
-  async getRecordPathFromProcArg(): Promise<string> {
-    return await ipcRenderer.invoke(Background.GET_RECORD_PATH_FROM_PROC_ARG);
+  async fetchInitialRecordFileRequest(): Promise<string> {
+    return await ipcRenderer.invoke(Background.FETCH_INITIAL_RECORD_FILE_REQUEST);
   },
   updateAppState(appState: AppState, bussy: boolean): void {
     ipcRenderer.send(Background.UPDATE_APP_STATE, appState, bussy);

--- a/src/renderer/ipc/web.ts
+++ b/src/renderer/ipc/web.ts
@@ -24,8 +24,8 @@ enum STORAGE_KEY {
 
 // Electron を使わずにシンプルな Web アプリケーションとして実行した場合に使用します。
 export const webAPI: Bridge = {
-  async getRecordPathFromProcArg(): Promise<string> {
-    return "";
+  async fetchInitialRecordFileRequest(): Promise<string> {
+    return "null";
   },
   updateAppState(): void {
     // DO NOTHING

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -968,7 +968,7 @@ class Store {
     }
   }
 
-  openRecord(path?: string): void {
+  openRecord(path?: string, opt?: { ply?: number }): void {
     if (this.appState !== AppState.NORMAL || this.isBussy) {
       this.pushError(t.pleaseEndActiveFeaturesBeforeOpenRecord);
       return;
@@ -990,6 +990,11 @@ class Store {
           });
           return e && Promise.reject(e);
         });
+      })
+      .then(() => {
+        if (opt?.ply) {
+          this.recordManager.changePly(opt.ply);
+        }
       })
       .catch((e) => {
         this.pushError("棋譜の読み込み中にエラーが出ました: " + e);

--- a/src/tests/background/args.spec.ts
+++ b/src/tests/background/args.spec.ts
@@ -1,0 +1,35 @@
+import { fetchInitialRecordFileRequest, setInitialFilePath } from "@/background/args";
+
+describe("args", () => {
+  afterEach(() => {
+    setInitialFilePath("");
+  });
+
+  it("normal", () => {
+    process.argv = ["node", "/path/to/record.kif"];
+    const request = fetchInitialRecordFileRequest();
+    expect(request?.path).toEqual("/path/to/record.kif");
+    expect(request?.ply).toBeUndefined();
+  });
+
+  it("ShogiGUI-style", () => {
+    process.argv = ["node", "/path/to/record.kif", "-n", "123"];
+    const request = fetchInitialRecordFileRequest();
+    expect(request?.path).toEqual("/path/to/record.kif");
+    expect(request?.ply).toBe(123);
+  });
+
+  it("KifuBase-style", () => {
+    process.argv = ["node", "/path/to/record.kif", "+123"];
+    const request = fetchInitialRecordFileRequest();
+    expect(request?.path).toEqual("/path/to/record.kif");
+    expect(request?.ply).toBe(123);
+  });
+
+  it("mac", () => {
+    setInitialFilePath("/path/to/record.kif");
+    const request = fetchInitialRecordFileRequest();
+    expect(request?.path).toEqual("/path/to/record.kif");
+    expect(request?.ply).toBeUndefined();
+  });
+});


### PR DESCRIPTION
# 説明 / Description

#672 

起動時引数のサポートを強化する。

- 知らないオプションを無視する。
- 棋譜を読み込んだ後に指定された手数へジャンプする。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [ ] i18n
