### PR TITLE
予想手が合法手かどうかを検証する機能

### DIFF
--- a/src/renderer/players/usi.ts
+++ b/src/renderer/players/usi.ts
@@ -72,21 +72,26 @@ export class USIPlayer implements Player {
     blackTimeMs: number,
     whiteTimeMs: number,
   ): Promise<void> {
-    const baseUSI = record.usi;
-    if (!this.ponder || !this.ponder.startsWith(baseUSI)) {
-      return;
-    }
+    // エンジンの USI_Ponder オプションが無効なら何もしない。
     const ponderSetting = getUSIEngineOptionCurrentValue(this.setting.options[USIPonder]);
     if (ponderSetting !== "true") {
       return;
     }
+    // 現在局面までの USI が前方一致しているか確認する。
+    const baseUSI = record.usi;
+    if (!this.ponder || !this.ponder.startsWith(baseUSI)) {
+      return;
+    }
+    // 予想した 1 手を取り出す。
+    const ponderMove = record.position.createMoveByUSI(this.ponder.slice(baseUSI.length + 1));
+    // 合法手かどうかをチェックする。
+    if (!ponderMove || !record.position.isValidMove(ponderMove)) {
+      return;
+    }
+
     this.clearHandlers();
     this.usi = this.ponder;
     this.position = record.position.clone();
-    const ponderMove = this.position.createMoveByUSI(this.ponder.slice(baseUSI.length + 1));
-    if (!ponderMove) {
-      return;
-    }
     this.position.doMove(ponderMove);
     this.info = undefined;
     this.inPonder = true;

--- a/src/tests/renderer/players/usi.spec.ts
+++ b/src/tests/renderer/players/usi.spec.ts
@@ -52,4 +52,32 @@ describe("usi", () => {
       await player.close();
     }
   });
+
+  it("illegalPonderMove", async () => {
+    mockAPI.usiLaunch.mockResolvedValueOnce(100);
+    mockAPI.usiGo.mockResolvedValueOnce();
+    mockAPI.usiGoPonder.mockResolvedValueOnce();
+    const usi1 = "position startpos moves 7g7f 3c3d";
+    const usi2 = "position startpos moves 7g7f 3c3d 2g2f";
+    const record1 = Record.newByUSI(usi1) as Record;
+    const record2 = Record.newByUSI(usi2) as Record;
+    const player = new USIPlayer(usiEngineSettingWithPonder, 10);
+    try {
+      await player.launch();
+      const searchHandler = {
+        onMove: vi.fn(),
+        onResign: vi.fn(),
+        onWin: vi.fn(),
+        onError: vi.fn(),
+      };
+      await player.startSearch(record1, timeLimitSetting, 0, 0, searchHandler);
+      expect(mockAPI.usiGo).toBeCalledWith(100, usi1, timeLimitSetting, 0, 0);
+      onUSIBestMove(100, usi1, "2g2f", "4a3a");
+      expect(searchHandler.onMove.mock.calls[0][0].usi).toBe("2g2f");
+      await player.startPonder(record2, timeLimitSetting, 0, 0);
+      expect(mockAPI.usiGoPonder).not.toBeCalled();
+    } finally {
+      await player.close();
+    }
+  });
 });


### PR DESCRIPTION
# 説明 / Description

#686 

bestmove コマンドの予想手 (ponder) でエンジンが反則手を送ってきた事例がある。
具体的には 1 手で自分が詰ましたことで相手の合法手が全く存在しない場合に発生した。
エンジンの多くは王手放置の手も列挙した上で、王様が取られたら負け、という判定をしている。
そのためエンジン側で予想手をチェックする仕組みを作っていないと、反則手が送られてしまう。

加えてその事例では go ponder で Ponder を開始したときにエンジンがクラッシュした。
GUI からするとエンジンが自己申告したものを本人に送り返しているだけではあるのだが、
合法手チェックをしてあげた方が親切ではあるし、比較的簡単な実装なので加えておく。

この実装によって、予想手が合法手でない場合は先読みを実行しなくなる。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
