### PR TITLE
update test

### DIFF
--- a/src/tests/background/version/version.spec.ts
+++ b/src/tests/background/version/version.spec.ts
@@ -12,12 +12,21 @@ const lastUpdatedMs = 1000000000;
 const time23HoursAfter = lastUpdatedMs + 23 * 60 * 60 * 1000;
 const time25HoursAfter = lastUpdatedMs + 25 * 60 * 60 * 1000;
 
-function setup(param: {
+type MockParam = {
   knownStable?: string;
   knownLatest?: string;
   stable: string;
   latest: string;
-}) {
+};
+
+const server = {
+  param: { stable: "", latest: "" } as MockParam,
+  accessCount: 0,
+  invalidCount: 0,
+  close: () => {},
+};
+
+function reset(param: MockParam) {
   if (param.knownStable && param.knownLatest) {
     const status: VersionStatus = {
       knownReleases: {
@@ -37,24 +46,25 @@ function setup(param: {
     };
     fs.writeFileSync(statusFilePath, JSON.stringify(status));
   }
-  const releases: Releases = {
-    stable: {
-      version: param.stable,
-      tag: `v${param.stable}`,
-      link: "https://link/to/stable",
-    },
-    latest: {
-      version: param.latest,
-      tag: `v${param.latest}`,
-      link: "https://link/to/latest",
-    },
-  };
-  const server = {
-    accessCount: 0,
-    invalidCount: 0,
-    close: () => {},
-  };
+  server.param = param;
+  server.accessCount = 0;
+  server.invalidCount = 0;
+}
+
+function setupServer() {
   const s = http.createServer((req, res) => {
+    const releases: Releases = {
+      stable: {
+        version: server.param.stable,
+        tag: `v${server.param.stable}`,
+        link: "https://link/to/stable",
+      },
+      latest: {
+        version: server.param.latest,
+        tag: `v${server.param.latest}`,
+        link: "https://link/to/latest",
+      },
+    };
     if (req.url === "/release.json") {
       server.accessCount++;
       res.writeHead(200, { "Content-Type": "application/json" });
@@ -69,10 +79,17 @@ function setup(param: {
   server.close = () => {
     s.close();
   };
-  return server;
 }
 
 describe("version", () => {
+  beforeAll(() => {
+    setupServer();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
   beforeEach(() => {
     vi.useFakeTimers();
   });
@@ -83,271 +100,221 @@ describe("version", () => {
   });
 
   it("no_status_file/patch_update/stable", async () => {
-    const mockParam = {
-      stable: "v1.0.4",
-      latest: "v1.1.1",
-    };
+    reset({
+      stable: "1.0.4",
+      latest: "1.1.1",
+    });
     vi.setSystemTime(time25HoursAfter);
     vi.spyOn(electron, "getAppVersion").mockReturnValue("v1.0.1");
     const spy = vi.spyOn(electron, "showNotification").mockImplementation(() => {});
-    const server = setup(mockParam);
-    try {
-      await checkUpdates();
-      expect(spy.mock.calls).toHaveLength(1);
-      expect(spy.mock.calls[0][0]).toBe("Electron将棋");
-      expect(spy.mock.calls[0][1]).toBe("安定版 v1.0.4 がリリースされました！");
-      expect(server.accessCount).toBe(1);
-      expect(server.invalidCount).toBe(0);
-      const status = JSON.parse(fs.readFileSync(statusFilePath, "utf8")) as VersionStatus;
-      expect(status.knownReleases?.stable.version).toBe("v1.0.4");
-      expect(status.knownReleases?.latest.version).toBe("v1.1.1");
-      expect(status.knownReleases?.downloadedMs).toBe(time25HoursAfter);
-      expect(status.updatedMs).toBe(time25HoursAfter);
-    } finally {
-      server.close();
-    }
+    await checkUpdates();
+    expect(spy.mock.calls).toHaveLength(1);
+    expect(spy.mock.calls[0][0]).toBe("Electron将棋");
+    expect(spy.mock.calls[0][1]).toBe("安定版 v1.0.4 がリリースされました！");
+    expect(server.accessCount).toBe(1);
+    expect(server.invalidCount).toBe(0);
+    const status = JSON.parse(fs.readFileSync(statusFilePath, "utf8")) as VersionStatus;
+    expect(status.knownReleases?.stable.version).toBe("1.0.4");
+    expect(status.knownReleases?.latest.version).toBe("1.1.1");
+    expect(status.knownReleases?.downloadedMs).toBe(time25HoursAfter);
+    expect(status.updatedMs).toBe(time25HoursAfter);
   });
 
   it("status_file_exists/patch_update/latest", async () => {
-    const mockParam = {
-      knownStable: "v1.0.3",
-      knownLatest: "v1.1.0",
-      stable: "v1.0.4",
-      latest: "v1.1.1",
-    };
+    reset({
+      knownStable: "1.0.3",
+      knownLatest: "1.1.0",
+      stable: "1.0.4",
+      latest: "1.1.1",
+    });
     vi.setSystemTime(time25HoursAfter);
     vi.spyOn(electron, "getAppVersion").mockReturnValue("v1.1.0");
     const spy = vi.spyOn(electron, "showNotification").mockImplementation(() => {});
-    const server = setup(mockParam);
-    try {
-      await checkUpdates();
-      expect(spy.mock.calls).toHaveLength(1);
-      expect(spy.mock.calls[0][0]).toBe("Electron将棋");
-      expect(spy.mock.calls[0][1]).toBe("最新版 v1.1.1 がリリースされました！");
-      expect(server.accessCount).toBe(1);
-      expect(server.invalidCount).toBe(0);
-      const status = JSON.parse(fs.readFileSync(statusFilePath, "utf8")) as VersionStatus;
-      expect(status.knownReleases?.stable.version).toBe("v1.0.4");
-      expect(status.knownReleases?.latest.version).toBe("v1.1.1");
-      expect(status.knownReleases?.downloadedMs).toBe(time25HoursAfter);
-      expect(status.updatedMs).toBe(time25HoursAfter);
-    } finally {
-      server.close();
-    }
+    await checkUpdates();
+    expect(spy.mock.calls).toHaveLength(1);
+    expect(spy.mock.calls[0][0]).toBe("Electron将棋");
+    expect(spy.mock.calls[0][1]).toBe("最新版 v1.1.1 がリリースされました！");
+    expect(server.accessCount).toBe(1);
+    expect(server.invalidCount).toBe(0);
+    const status = JSON.parse(fs.readFileSync(statusFilePath, "utf8")) as VersionStatus;
+    expect(status.knownReleases?.stable.version).toBe("1.0.4");
+    expect(status.knownReleases?.latest.version).toBe("1.1.1");
+    expect(status.knownReleases?.downloadedMs).toBe(time25HoursAfter);
+    expect(status.updatedMs).toBe(time25HoursAfter);
   });
 
   it("status_file_exists/known_updates", async () => {
-    const mockParam = {
-      knownStable: "v1.0.4",
-      knownLatest: "v1.1.1",
-      stable: "v1.0.4",
-      latest: "v1.1.1",
-    };
+    reset({
+      knownStable: "1.0.4",
+      knownLatest: "1.1.1",
+      stable: "1.0.4",
+      latest: "1.1.1",
+    });
     vi.setSystemTime(time25HoursAfter);
     vi.spyOn(electron, "getAppVersion").mockReturnValue("v1.0.1");
     const spy = vi.spyOn(electron, "showNotification").mockImplementation(() => {});
-    const server = setup(mockParam);
-    try {
-      await checkUpdates();
-      expect(spy.mock.calls).toHaveLength(0);
-      expect(server.accessCount).toBe(1);
-      expect(server.invalidCount).toBe(0);
-      const status = JSON.parse(fs.readFileSync(statusFilePath, "utf8")) as VersionStatus;
-      expect(status.knownReleases?.stable.version).toBe("v1.0.4");
-      expect(status.knownReleases?.latest.version).toBe("v1.1.1");
-      expect(status.knownReleases?.downloadedMs).toBe(time25HoursAfter);
-      expect(status.updatedMs).toBe(time25HoursAfter);
-    } finally {
-      server.close();
-    }
+    await checkUpdates();
+    expect(spy.mock.calls).toHaveLength(0);
+    expect(server.accessCount).toBe(1);
+    expect(server.invalidCount).toBe(0);
+    const status = JSON.parse(fs.readFileSync(statusFilePath, "utf8")) as VersionStatus;
+    expect(status.knownReleases?.stable.version).toBe("1.0.4");
+    expect(status.knownReleases?.latest.version).toBe("1.1.1");
+    expect(status.knownReleases?.downloadedMs).toBe(time25HoursAfter);
+    expect(status.updatedMs).toBe(time25HoursAfter);
   });
 
   it("status_file_exists/patch_update/alpha_installed", async () => {
-    const mockParam = {
-      knownStable: "v1.0.3",
-      knownLatest: "v1.1.0",
-      stable: "v1.0.4",
-      latest: "v1.1.1",
-    };
+    reset({
+      knownStable: "1.0.3",
+      knownLatest: "1.1.0",
+      stable: "1.0.4",
+      latest: "1.1.1",
+    });
     vi.setSystemTime(time25HoursAfter);
     vi.spyOn(electron, "getAppVersion").mockReturnValue("v1.2.0-alpha.1");
     const spy = vi.spyOn(electron, "showNotification").mockImplementation(() => {});
-    const server = setup(mockParam);
-    try {
-      await checkUpdates();
-      expect(spy.mock.calls).toHaveLength(0);
-      expect(server.accessCount).toBe(1);
-      expect(server.invalidCount).toBe(0);
-      const status = JSON.parse(fs.readFileSync(statusFilePath, "utf8")) as VersionStatus;
-      expect(status.knownReleases?.stable.version).toBe("v1.0.4");
-      expect(status.knownReleases?.latest.version).toBe("v1.1.1");
-      expect(status.knownReleases?.downloadedMs).toBe(time25HoursAfter);
-      expect(status.updatedMs).toBe(time25HoursAfter);
-    } finally {
-      server.close();
-    }
+    await checkUpdates();
+    expect(spy.mock.calls).toHaveLength(0);
+    expect(server.accessCount).toBe(1);
+    expect(server.invalidCount).toBe(0);
+    const status = JSON.parse(fs.readFileSync(statusFilePath, "utf8")) as VersionStatus;
+    expect(status.knownReleases?.stable.version).toBe("1.0.4");
+    expect(status.knownReleases?.latest.version).toBe("1.1.1");
+    expect(status.knownReleases?.downloadedMs).toBe(time25HoursAfter);
+    expect(status.updatedMs).toBe(time25HoursAfter);
   });
 
   it("status_file_exists/skip_download", async () => {
-    const mockParam = {
-      knownStable: "v1.0.3",
-      knownLatest: "v1.1.0",
-      stable: "v1.0.4",
-      latest: "v1.1.1",
-    };
+    reset({
+      knownStable: "1.0.3",
+      knownLatest: "1.1.0",
+      stable: "1.0.4",
+      latest: "1.1.1",
+    });
     vi.setSystemTime(time23HoursAfter);
     const spy = vi.spyOn(electron, "showNotification").mockImplementation(() => {});
-    const server = setup(mockParam);
-    try {
-      await checkUpdates();
-      expect(spy.mock.calls).toHaveLength(0);
-      expect(server.accessCount).toBe(0);
-      expect(server.invalidCount).toBe(0);
-      const status = JSON.parse(fs.readFileSync(statusFilePath, "utf8")) as VersionStatus;
-      expect(status.knownReleases?.stable.version).toBe("v1.0.3"); // not updated
-      expect(status.knownReleases?.latest.version).toBe("v1.1.0"); // not updated
-      expect(status.knownReleases?.downloadedMs).toBe(lastUpdatedMs); // not updated
-      expect(status.updatedMs).toBe(time23HoursAfter);
-    } finally {
-      server.close();
-    }
+    await checkUpdates();
+    expect(spy.mock.calls).toHaveLength(0);
+    expect(server.accessCount).toBe(0);
+    expect(server.invalidCount).toBe(0);
+    const status = JSON.parse(fs.readFileSync(statusFilePath, "utf8")) as VersionStatus;
+    expect(status.knownReleases?.stable.version).toBe("1.0.3"); // not updated
+    expect(status.knownReleases?.latest.version).toBe("1.1.0"); // not updated
+    expect(status.knownReleases?.downloadedMs).toBe(lastUpdatedMs); // not updated
+    expect(status.updatedMs).toBe(time23HoursAfter);
   });
 
   it("status_file_exists/patch_update/only_stable", async () => {
     // 安定版が更新されたが最新版をインストールしているので通知しない。
-    const mockParam = {
-      knownStable: "v1.0.3",
-      knownLatest: "v1.1.1",
-      stable: "v1.0.4",
-      latest: "v1.1.1",
-    };
+    reset({
+      knownStable: "1.0.3",
+      knownLatest: "1.1.1",
+      stable: "1.0.4",
+      latest: "1.1.1",
+    });
     vi.setSystemTime(time25HoursAfter);
     vi.spyOn(electron, "getAppVersion").mockReturnValue("v1.1.1");
     const spy = vi.spyOn(electron, "showNotification").mockImplementation(() => {});
-    const server = setup(mockParam);
-    try {
-      await checkUpdates();
-      expect(spy.mock.calls).toHaveLength(0);
-      expect(server.accessCount).toBe(1);
-      expect(server.invalidCount).toBe(0);
-      const status = JSON.parse(fs.readFileSync(statusFilePath, "utf8")) as VersionStatus;
-      expect(status.knownReleases?.stable.version).toBe("v1.0.4");
-      expect(status.knownReleases?.latest.version).toBe("v1.1.1");
-      expect(status.knownReleases?.downloadedMs).toBe(time25HoursAfter);
-      expect(status.updatedMs).toBe(time25HoursAfter);
-    } finally {
-      server.close();
-    }
+    await checkUpdates();
+    expect(spy.mock.calls).toHaveLength(0);
+    expect(server.accessCount).toBe(1);
+    expect(server.invalidCount).toBe(0);
+    const status = JSON.parse(fs.readFileSync(statusFilePath, "utf8")) as VersionStatus;
+    expect(status.knownReleases?.stable.version).toBe("1.0.4");
+    expect(status.knownReleases?.latest.version).toBe("1.1.1");
+    expect(status.knownReleases?.downloadedMs).toBe(time25HoursAfter);
+    expect(status.updatedMs).toBe(time25HoursAfter);
   });
 
   it("status_file_exists/patch_update/only_latest", async () => {
     // 最新版が更新されたが安定版をインストールしているので通知しない。
-    const mockParam = {
-      knownStable: "v1.0.3",
-      knownLatest: "v1.1.1",
-      stable: "v1.0.3",
-      latest: "v1.1.2",
-    };
+    reset({
+      knownStable: "1.0.3",
+      knownLatest: "1.1.1",
+      stable: "1.0.3",
+      latest: "1.1.2",
+    });
     vi.setSystemTime(time25HoursAfter);
     vi.spyOn(electron, "getAppVersion").mockReturnValue("v1.0.2");
     const spy = vi.spyOn(electron, "showNotification").mockImplementation(() => {});
-    const server = setup(mockParam);
-    try {
-      await checkUpdates();
-      expect(spy.mock.calls).toHaveLength(0);
-      expect(server.accessCount).toBe(1);
-      expect(server.invalidCount).toBe(0);
-      const status = JSON.parse(fs.readFileSync(statusFilePath, "utf8")) as VersionStatus;
-      expect(status.knownReleases?.stable.version).toBe("v1.0.3");
-      expect(status.knownReleases?.latest.version).toBe("v1.1.2");
-      expect(status.knownReleases?.downloadedMs).toBe(time25HoursAfter);
-      expect(status.updatedMs).toBe(time25HoursAfter);
-    } finally {
-      server.close();
-    }
+    await checkUpdates();
+    expect(spy.mock.calls).toHaveLength(0);
+    expect(server.accessCount).toBe(1);
+    expect(server.invalidCount).toBe(0);
+    const status = JSON.parse(fs.readFileSync(statusFilePath, "utf8")) as VersionStatus;
+    expect(status.knownReleases?.stable.version).toBe("1.0.3");
+    expect(status.knownReleases?.latest.version).toBe("1.1.2");
+    expect(status.knownReleases?.downloadedMs).toBe(time25HoursAfter);
+    expect(status.updatedMs).toBe(time25HoursAfter);
   });
 
   it("status_file_exists/minor_update/stable", async () => {
-    const mockParam = {
-      knownStable: "v1.0.4",
-      knownLatest: "v1.1.1",
-      stable: "v1.1.1",
-      latest: "v1.2.0",
-    };
+    reset({
+      knownStable: "1.0.4",
+      knownLatest: "1.1.1",
+      stable: "1.1.1",
+      latest: "1.2.0",
+    });
     vi.setSystemTime(time25HoursAfter);
     vi.spyOn(electron, "getAppVersion").mockReturnValue("v1.0.4");
     const spy = vi.spyOn(electron, "showNotification").mockImplementation(() => {});
-    const server = setup(mockParam);
-    try {
-      await checkUpdates();
-      expect(spy.mock.calls).toHaveLength(1);
-      expect(spy.mock.calls[0][0]).toBe("Electron将棋");
-      expect(spy.mock.calls[0][1]).toBe("安定版 v1.1.1 がリリースされました！");
-      expect(server.accessCount).toBe(1);
-      expect(server.invalidCount).toBe(0);
-      const status = JSON.parse(fs.readFileSync(statusFilePath, "utf8")) as VersionStatus;
-      expect(status.knownReleases?.stable.version).toBe("v1.1.1");
-      expect(status.knownReleases?.latest.version).toBe("v1.2.0");
-      expect(status.knownReleases?.downloadedMs).toBe(time25HoursAfter);
-      expect(status.updatedMs).toBe(time25HoursAfter);
-    } finally {
-      server.close();
-    }
+    await checkUpdates();
+    expect(spy.mock.calls).toHaveLength(1);
+    expect(spy.mock.calls[0][0]).toBe("Electron将棋");
+    expect(spy.mock.calls[0][1]).toBe("安定版 v1.1.1 がリリースされました！");
+    expect(server.accessCount).toBe(1);
+    expect(server.invalidCount).toBe(0);
+    const status = JSON.parse(fs.readFileSync(statusFilePath, "utf8")) as VersionStatus;
+    expect(status.knownReleases?.stable.version).toBe("1.1.1");
+    expect(status.knownReleases?.latest.version).toBe("1.2.0");
+    expect(status.knownReleases?.downloadedMs).toBe(time25HoursAfter);
+    expect(status.updatedMs).toBe(time25HoursAfter);
   });
 
   it("status_file_exists/minor_update/latest", async () => {
-    const mockParam = {
-      knownStable: "v1.0.4",
-      knownLatest: "v1.1.1",
-      stable: "v1.1.1",
-      latest: "v1.2.0",
-    };
+    reset({
+      knownStable: "1.0.4",
+      knownLatest: "1.1.1",
+      stable: "1.1.1",
+      latest: "1.2.0",
+    });
     vi.setSystemTime(time25HoursAfter);
     vi.spyOn(electron, "getAppVersion").mockReturnValue("v1.1.1");
     const spy = vi.spyOn(electron, "showNotification").mockImplementation(() => {});
-    const server = setup(mockParam);
-    try {
-      await checkUpdates();
-      expect(spy.mock.calls).toHaveLength(1);
-      expect(spy.mock.calls[0][0]).toBe("Electron将棋");
-      expect(spy.mock.calls[0][1]).toBe("最新版 v1.2.0 がリリースされました！");
-      expect(server.accessCount).toBe(1);
-      expect(server.invalidCount).toBe(0);
-      const status = JSON.parse(fs.readFileSync(statusFilePath, "utf8")) as VersionStatus;
-      expect(status.knownReleases?.stable.version).toBe("v1.1.1");
-      expect(status.knownReleases?.latest.version).toBe("v1.2.0");
-      expect(status.knownReleases?.downloadedMs).toBe(time25HoursAfter);
-      expect(status.updatedMs).toBe(time25HoursAfter);
-    } finally {
-      server.close();
-    }
+    await checkUpdates();
+    expect(spy.mock.calls).toHaveLength(1);
+    expect(spy.mock.calls[0][0]).toBe("Electron将棋");
+    expect(spy.mock.calls[0][1]).toBe("最新版 v1.2.0 がリリースされました！");
+    expect(server.accessCount).toBe(1);
+    expect(server.invalidCount).toBe(0);
+    const status = JSON.parse(fs.readFileSync(statusFilePath, "utf8")) as VersionStatus;
+    expect(status.knownReleases?.stable.version).toBe("1.1.1");
+    expect(status.knownReleases?.latest.version).toBe("1.2.0");
+    expect(status.knownReleases?.downloadedMs).toBe(time25HoursAfter);
+    expect(status.updatedMs).toBe(time25HoursAfter);
   });
 
   it("status_file_exists/minor_update/alpha_installed", async () => {
-    const mockParam = {
-      knownStable: "v1.0.3",
-      knownLatest: "v1.1.1",
-      stable: "v1.1.1",
-      latest: "v1.2.0",
-    };
+    reset({
+      knownStable: "1.0.3",
+      knownLatest: "1.1.1",
+      stable: "1.1.1",
+      latest: "1.2.0",
+    });
     vi.setSystemTime(time25HoursAfter);
     vi.spyOn(electron, "getAppVersion").mockReturnValue("v1.2.0-alpha.1");
     const spy = vi.spyOn(electron, "showNotification").mockImplementation(() => {});
-    const server = setup(mockParam);
-    try {
-      await checkUpdates();
-      expect(spy.mock.calls).toHaveLength(1);
-      expect(spy.mock.calls[0][0]).toBe("Electron将棋");
-      expect(spy.mock.calls[0][1]).toBe("最新版 v1.2.0 がリリースされました！");
-      expect(server.accessCount).toBe(1);
-      expect(server.invalidCount).toBe(0);
-      const status = JSON.parse(fs.readFileSync(statusFilePath, "utf8")) as VersionStatus;
-      expect(status.knownReleases?.stable.version).toBe("v1.1.1");
-      expect(status.knownReleases?.latest.version).toBe("v1.2.0");
-      expect(status.knownReleases?.downloadedMs).toBe(time25HoursAfter);
-      expect(status.updatedMs).toBe(time25HoursAfter);
-    } finally {
-      server.close();
-    }
+    await checkUpdates();
+    expect(spy.mock.calls).toHaveLength(1);
+    expect(spy.mock.calls[0][0]).toBe("Electron将棋");
+    expect(spy.mock.calls[0][1]).toBe("最新版 v1.2.0 がリリースされました！");
+    expect(server.accessCount).toBe(1);
+    expect(server.invalidCount).toBe(0);
+    const status = JSON.parse(fs.readFileSync(statusFilePath, "utf8")) as VersionStatus;
+    expect(status.knownReleases?.stable.version).toBe("1.1.1");
+    expect(status.knownReleases?.latest.version).toBe("1.2.0");
+    expect(status.knownReleases?.downloadedMs).toBe(time25HoursAfter);
+    expect(status.updatedMs).toBe(time25HoursAfter);
   });
 });


### PR DESCRIPTION
# 説明 / Description

テストの実行中にモックサーバーが同じポートを使いまわす時に立ち上げに失敗することがあるので、1回開いたポートを使いまわすようにする。
また、テストで使用している semver の表記が間違っているので修正する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [ ] i18n
