### PR TITLE
Macアプリでテキスト操作のショートカットキーが効かない問題を修正

### DIFF
--- a/src/background/window/menu.ts
+++ b/src/background/window/menu.ts
@@ -83,7 +83,7 @@ function createMenuTemplate() {
         {
           label: t.copyRecord,
           submenu: [
-            menuItem(t.asKIF, MenuEvent.COPY_RECORD, null, "CmdOrCtrl+C"),
+            menuItem(t.asKIF, MenuEvent.COPY_RECORD, null, isMac ? undefined : "CmdOrCtrl+C"),
             menuItem(t.asKI2, MenuEvent.COPY_RECORD_KI2, null),
             menuItem(t.asCSA, MenuEvent.COPY_RECORD_CSA, null),
             menuItem(t.asUSIUntilCurrentMove, MenuEvent.COPY_RECORD_USI_BEFORE, null),
@@ -92,7 +92,12 @@ function createMenuTemplate() {
           ],
         },
         menuItem(t.copyPositionAsSFEN, MenuEvent.COPY_BOARD_SFEN, null),
-        menuItem(t.pasteRecordOrPosition, MenuEvent.PASTE_RECORD, [AppState.NORMAL], "CmdOrCtrl+V"),
+        menuItem(
+          t.pasteRecordOrPosition,
+          MenuEvent.PASTE_RECORD,
+          [AppState.NORMAL],
+          isMac ? undefined : "CmdOrCtrl+V",
+        ),
         { type: "separator" },
         {
           label: t.appendSpecialMove,
@@ -232,6 +237,16 @@ function createMenuTemplate() {
             ),
           ],
         },
+        // NOTE:
+        //   Mac ではこれらのショートカットがメニューに無いとテキスト編集時のショートカット操作ができない。
+        //   https://github.com/sunfish-shogi/electron-shogi/issues/694
+        { type: "separator", visible: isMac },
+        { role: "copy", accelerator: "CmdOrCtrl+C", visible: isMac },
+        { role: "paste", accelerator: "CmdOrCtrl+V", visible: isMac },
+        { role: "cut", accelerator: "CmdOrCtrl+X", visible: isMac },
+        { role: "undo", accelerator: "CmdOrCtrl+Z", visible: isMac },
+        { role: "redo", accelerator: "CmdOrCtrl+Shift+Z", visible: isMac },
+        { role: "selectAll", accelerator: "CmdOrCtrl+A", visible: isMac },
       ],
     },
     {
@@ -255,7 +270,12 @@ function createMenuTemplate() {
         menuItem(t.startResearch, MenuEvent.START_RESEARCH, [AppState.NORMAL], "CmdOrCtrl+R"),
         menuItem(t.endResearch, MenuEvent.STOP_RESEARCH, [AppState.RESEARCH]),
         { type: "separator" },
-        menuItem(t.analyze, MenuEvent.START_ANALYSIS, [AppState.NORMAL], "CmdOrCtrl+A"),
+        menuItem(
+          t.analyze,
+          MenuEvent.START_ANALYSIS,
+          [AppState.NORMAL],
+          isMac ? undefined : "CmdOrCtrl+A",
+        ),
         menuItem(t.stopAnalysis, MenuEvent.STOP_ANALYSIS, [AppState.ANALYSIS]),
       ],
     },

--- a/src/renderer/view/dialog/PVPreviewDialog.vue
+++ b/src/renderer/view/dialog/PVPreviewDialog.vue
@@ -20,7 +20,7 @@
         <template #right-control>
           <div class="full column">
             <div class="row control-row">
-              <button class="control-item" data-hotkey="Control+t" @click="doFlip">
+              <button class="control-item" data-hotkey="Mod+t" @click="doFlip">
                 <Icon :icon="IconType.FLIP" />
               </button>
               <button class="control-item" autofocus data-hotkey="Escape" @click="close">

--- a/src/renderer/view/main/BoardPane.vue
+++ b/src/renderer/view/main/BoardPane.vue
@@ -72,7 +72,7 @@
           <button
             v-if="controlStates.research"
             class="control-item"
-            data-hotkey="Control+r"
+            data-hotkey="Mod+r"
             @click="onResearch"
           >
             <Icon :icon="IconType.RESEARCH" />
@@ -90,7 +90,7 @@
           <button
             v-if="controlStates.analysis"
             class="control-item"
-            data-hotkey="Control+a"
+            data-hotkey="Mod+a"
             @click="onAnalysis"
           >
             <Icon :icon="IconType.ANALYSIS" />
@@ -108,7 +108,7 @@
           <button
             v-if="controlStates.mateSearch"
             class="control-item"
-            data-hotkey="Control+m"
+            data-hotkey="Mod+m"
             @click="onMateSearch"
           >
             <Icon :icon="IconType.MATE_SEARCH" />
@@ -157,20 +157,20 @@
             hidden: appSetting.leftSideControlType === LeftSideControlType.NONE,
           }"
         >
-          <button class="control-item" data-hotkey="Control+," @click="onOpenAppSettings">
+          <button class="control-item" data-hotkey="Mod+," @click="onOpenAppSettings">
             <Icon :icon="IconType.SETTINGS" />
             <span>{{ t.appSettings }}</span>
           </button>
           <button
             class="control-item"
-            data-hotkey="Control+."
+            data-hotkey="Mod+."
             :disabled="!controlStates.engineSettings"
             @click="onOpenEngineSettings"
           >
             <Icon :icon="IconType.ENGINE_SETTINGS" />
             <span>{{ t.engineSettings }}</span>
           </button>
-          <button class="control-item" data-hotkey="Control+t" @click="onFlip">
+          <button class="control-item" data-hotkey="Mod+t" @click="onFlip">
             <Icon :icon="IconType.FLIP" />
             <span>{{ t.flipBoard }}</span>
           </button>
@@ -180,7 +180,7 @@
           </button>
           <button
             class="control-item"
-            data-hotkey="Control+d"
+            data-hotkey="Mod+d"
             :disabled="!controlStates.removeCurrentMove"
             @click="onRemoveCurrentMove"
           >


### PR DESCRIPTION
# 説明 / Description

#694 

Mac版アプリにおいて、テキスト入力エリア内で以下の操作ができない問題を修正する。

- コピー (Copy) - Cmd+C
- 貼り付け (Paste) - Cmd+V
- 切り取り (Cut) - Cmd+X
- 全選択 (Select All) - Cmd+A
- 元に戻す (Undo) - Cmd+Z
- 進める (Redo) - Cmd+Shift+Z

Macアプリでは、これらの操作に該当する role をメニューバーに作っておかないと、操作がレンダラーに反映されないようです。
そのため、 Mac版のみ「編集」メニューにこれら 6 つの項目を加えます。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
