### PR TITLE
Add app version section info AppSettingDialog

### DIFF
--- a/src/background/version/check.ts
+++ b/src/background/version/check.ts
@@ -23,7 +23,7 @@ const baseURL =
     : "https://sunfish-shogi.github.io/electron-shogi/";
 const releaseURL = url.resolve(baseURL, "release.json");
 
-async function readStatus(): Promise<VersionStatus> {
+export async function readStatus(): Promise<VersionStatus> {
   if (await exists(statusFilePath)) {
     getAppLogger().debug("version.json exists");
     const data = await fs.promises.readFile(statusFilePath, "utf8");

--- a/src/background/window/ipc.ts
+++ b/src/background/window/ipc.ts
@@ -75,6 +75,8 @@ import {
 import { getAppPath } from "@/background/proc/env";
 import { fetchInitialRecordFileRequest } from "@/background/proc/args";
 import { isSupportedRecordFilePath } from "@/background/file/extensions";
+import { readStatus as readVersionStatus } from "@/background/version/check";
+import { sendTestNotification } from "./debug";
 
 const isWindows = process.platform === "win32";
 
@@ -612,6 +614,16 @@ ipcMain.handle(Background.CSA_STOP, (event, sessionID: number): void => {
 ipcMain.handle(Background.IS_ENCRYPTION_AVAILABLE, (event): boolean => {
   validateIPCSender(event.senderFrame);
   return isEncryptionAvailable();
+});
+
+ipcMain.handle(Background.GET_VERSION_STATUS, async (event) => {
+  validateIPCSender(event.senderFrame);
+  return JSON.stringify(await readVersionStatus());
+});
+
+ipcMain.on(Background.SEND_TEST_NOTIFICATION, (event) => {
+  validateIPCSender(event.senderFrame);
+  sendTestNotification();
 });
 
 ipcMain.handle(Background.OPEN_LOG_FILE, (event, logType: LogType) => {

--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -47,6 +47,7 @@ export const en: Texts = {
   toggleDevTools: "Toggle Developer Tools",
   reloadCustomPieceImage: "Reload Custom Piece Image",
   folders: "Folders",
+  notification: "Notification",
   notificationTest: "Notification Test",
   thisIsTestNotification: "This is test notification.",
   app: "App",
@@ -367,6 +368,10 @@ export const en: Texts = {
   blunderThreshold: "Blunder Threshold",
   gothic: "Gothic",
   mincho: "Mincho",
+  appVersion: "App Version",
+  installed: "Installed",
+  stable: "Stable",
+  latest: "Latest",
   typeCustomTitleHere: "Type custom title here",
   displayEmptyElements: "Display Empty Elements",
   waitingForNewGame: "Waiting for new game.",
@@ -396,6 +401,11 @@ export const en: Texts = {
   pleaseUncheckSaveHistoryIfNotWantSave: "Please uncheck Save History, if you don't want to save.",
   csaProtocolSendPlaintextPasswordRegardlessOfHistory:
     "On CSA protocol, client send plaintext password regardless of history.",
+  whenNewVersionIsAvailableItWillBeNotified: "When new version is available, it will be notified.",
+  pleaseCheckMessageThisIsTestNotificationByAboveButton:
+    'Please check the message "This is test notification." by above button.',
+  ifNotWorkYouShouldAllowNotificationOnOSSetting:
+    "If it does not work, you should allow notification on OS setting.",
   areYouSureWantToResign: "Are you sure you want to resign?",
   areYouSureWantToDoDeclaration: "Are you sure you want to do declaration?",
   areYouSureWantToQuitGames: "Are you sure you want to quit games?",
@@ -425,6 +435,7 @@ export const en: Texts = {
   failedToSaveRecord: "Failed to save record.",
   failedToParseSFEN: "Failed to parse SFEN.",
   failedToDetectRecordFormat: "Failed to detect record format.",
+  unknown: "Unknown",
   unknownFileExtension: "Unknown file extension.",
   emptyRecordInput: "Empty record input.",
   invalidPieceName: "Invalid piece name",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -46,6 +46,7 @@ export const ja: Texts = {
   toggleDevTools: "開発者ツール表示切り替え",
   reloadCustomPieceImage: "カスタム駒画像をリロード",
   folders: "各種フォルダ",
+  notification: "通知",
   notificationTest: "通知テスト",
   thisIsTestNotification: "これは通知のテストです。",
   app: "アプリ",
@@ -366,6 +367,10 @@ export const ja: Texts = {
   blunderThreshold: "大悪手の閾値",
   gothic: "ゴシック体",
   mincho: "明朝体",
+  appVersion: "アプリバージョン",
+  installed: "インストール済み",
+  stable: "安定版",
+  latest: "最新版",
   typeCustomTitleHere: "ここに見出しを入力",
   displayEmptyElements: "未入力の項目を表示",
   waitingForNewGame: "対局開始を待っています。",
@@ -395,6 +400,11 @@ export const ja: Texts = {
     "保存したくない場合は「履歴に保存する」のチェックを外してください。",
   csaProtocolSendPlaintextPasswordRegardlessOfHistory:
     "なお、履歴の保存に関係なくCSAプロトコルの規格上パスワードは平文で送信されます。",
+  whenNewVersionIsAvailableItWillBeNotified: "新しいバージョンが利用可能になると通知されます。",
+  pleaseCheckMessageThisIsTestNotificationByAboveButton:
+    "上のボタンで「これは通知のテストです。」というメッセージを確認してください。",
+  ifNotWorkYouShouldAllowNotificationOnOSSetting:
+    "表示されない場合はOSの設定で通知を許可してください。",
   areYouSureWantToResign: "投了しますか？",
   areYouSureWantToDoDeclaration: "宣言しますか？",
   areYouSureWantToQuitGames: "連続対局を中断しますか？",
@@ -422,6 +432,7 @@ export const ja: Texts = {
   failedToSaveRecord: "棋譜の保存に失敗しました。",
   failedToParseSFEN: "SFENの読み込みに失敗しました。",
   failedToDetectRecordFormat: "棋譜形式を判別できませんでした。",
+  unknown: "不明",
   unknownFileExtension: "不明なファイル形式です。",
   emptyRecordInput: "棋譜が入力されていません。",
   invalidPieceName: "不正な駒",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -46,6 +46,7 @@ export const zh_tw: Texts = {
   toggleDevTools: "打開/關閉開發者工具顯示",
   reloadCustomPieceImage: "カスタム駒画像をリロード", // TODO: translate
   folders: "各種フォルダ", // TODO: translate
+  notification: "通知", // TODO: translate
   notificationTest: "通知テスト", // TODO: translate
   thisIsTestNotification: "これは通知のテストです。", // TODO: translate
   app: "App", // TODO: translate
@@ -366,6 +367,10 @@ export const zh_tw: Texts = {
   blunderThreshold: "大惡手閾値",
   gothic: "ゴシック体", // TODO: translate
   mincho: "明朝体", // TODO: translate
+  appVersion: "アプリバージョン", // TODO: translate
+  installed: "インストール済み", // TODO: translate
+  stable: "安定版", // TODO: translate
+  latest: "最新版", // TODO: translate
   typeCustomTitleHere: "輸入自定義標題",
   displayEmptyElements: "顯示未定義資料",
   waitingForNewGame: "正在等待下一場對局開始。",
@@ -392,6 +397,11 @@ export const zh_tw: Texts = {
     "由於無法使用系統的加密機能，輸入的密碼將會以明文保存。",
   pleaseUncheckSaveHistoryIfNotWantSave: "若不想保存密碼，請不要將「保存紀錄」勾選。",
   csaProtocolSendPlaintextPasswordRegardlessOfHistory: "不過，CSA協定仍會以明文傳輸您的密碼。",
+  whenNewVersionIsAvailableItWillBeNotified: "新しいバージョンが利用可能になると通知されます。", // TODO: translate
+  pleaseCheckMessageThisIsTestNotificationByAboveButton:
+    "上記のボタンで「これは通知のテストです。」というメッセージを確認してください。", // TODO: translate
+  ifNotWorkYouShouldAllowNotificationOnOSSetting:
+    "表示されない場合はOSの設定で通知を許可してください。", // TODO: translate
   areYouSureWantToResign: "投了しますか？", // TODO: translate
   areYouSureWantToDoDeclaration: "宣言しますか？", // TODO: translate
   areYouSureWantToQuitGames: "要中斷連續對局嗎？",
@@ -419,6 +429,7 @@ export const zh_tw: Texts = {
   failedToSaveRecord: "棋譜保存失敗。",
   failedToParseSFEN: "SFEN讀取失敗。",
   failedToDetectRecordFormat: "無法判別棋譜形式。",
+  unknown: "不明", // TODO: translate
   unknownFileExtension: "未知的檔案形式。",
   emptyRecordInput: "您尚未輸入棋譜。",
   invalidPieceName: "不合法的棋駒",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -44,6 +44,7 @@ export type Texts = {
   toggleDevTools: string;
   reloadCustomPieceImage: string;
   folders: string;
+  notification: string;
   notificationTest: string;
   thisIsTestNotification: string;
   app: string;
@@ -174,7 +175,6 @@ export type Texts = {
   autoSaving: string;
   autoSavingDirectory: string;
   recordFileName: string;
-
   select: string;
   positionOfUSIOutput: string;
   movesOfUSIOutput: string;
@@ -365,6 +365,10 @@ export type Texts = {
   blunderThreshold: string;
   gothic: string;
   mincho: string;
+  appVersion: string;
+  installed: string;
+  stable: string;
+  latest: string;
   typeCustomTitleHere: string;
   displayEmptyElements: string;
   waitingForNewGame: string;
@@ -389,6 +393,9 @@ export type Texts = {
   passwordWillSavedPlaintextBecauseOSSideEncryptionNotAvailable: string;
   pleaseUncheckSaveHistoryIfNotWantSave: string;
   csaProtocolSendPlaintextPasswordRegardlessOfHistory: string;
+  whenNewVersionIsAvailableItWillBeNotified: string;
+  pleaseCheckMessageThisIsTestNotificationByAboveButton: string;
+  ifNotWorkYouShouldAllowNotificationOnOSSetting: string;
   areYouSureWantToResign: string;
   areYouSureWantToDoDeclaration: string;
   areYouSureWantToQuitGames: string;
@@ -415,6 +422,7 @@ export type Texts = {
   failedToSaveRecord: string;
   failedToParseSFEN: string;
   failedToDetectRecordFormat: string;
+  unknown: string;
   unknownFileExtension: string;
   emptyRecordInput: string;
   invalidPieceName: string;

--- a/src/common/ipc/channel.ts
+++ b/src/common/ipc/channel.ts
@@ -57,6 +57,8 @@ export enum Background {
   CSA_WIN = "csaWin",
   CSA_STOP = "csaStop",
   IS_ENCRYPTION_AVAILABLE = "isEncryptionAvailable",
+  GET_VERSION_STATUS = "getVersionStatus",
+  SEND_TEST_NOTIFICATION = "sendTestNotification",
   OPEN_LOG_FILE = "openLogFile",
   LOG = "log",
   ON_CLOSABLE = "onClosable",

--- a/src/renderer/ipc/api.ts
+++ b/src/renderer/ipc/api.ts
@@ -16,6 +16,7 @@ import { BatchConversionSetting } from "@/common/settings/conversion";
 import { BatchConversionResult } from "@/common/file/conversion";
 import { RecordFileHistory } from "@/common/file/history";
 import { InitialRecordFileRequest } from "@/common/file/record";
+import { VersionStatus } from "@/background/version/types";
 
 type AppInfo = {
   appVersion?: string;
@@ -92,6 +93,8 @@ export interface Bridge {
   csaWin(sessionID: number): Promise<void>;
   csaStop(sessionID: number): Promise<void>;
   isEncryptionAvailable(): Promise<boolean>;
+  getVersionStatus(): Promise<string>;
+  sendTestNotification(): void;
   openLogFile(logType: LogType): void;
   log(level: LogLevel, message: string): void;
   onClosable(): void;
@@ -190,6 +193,8 @@ export interface API {
   csaWin(sessionID: number): Promise<void>;
   csaStop(sessionID: number): Promise<void>;
   isEncryptionAvailable(): Promise<boolean>;
+  getVersionStatus(): Promise<VersionStatus>;
+  sendTestNotification(): void;
   openLogFile(logType: LogType): void;
   log(level: LogLevel, message: string): void;
 }
@@ -301,6 +306,9 @@ const api: API = {
   },
   csaLogin(setting: CSAServerSetting): Promise<number> {
     return bridge.csaLogin(JSON.stringify(setting));
+  },
+  async getVersionStatus(): Promise<VersionStatus> {
+    return JSON.parse(await bridge.getVersionStatus());
   },
 };
 

--- a/src/renderer/ipc/preload.ts
+++ b/src/renderer/ipc/preload.ts
@@ -207,6 +207,12 @@ const api: Bridge = {
   async isEncryptionAvailable(): Promise<boolean> {
     return await ipcRenderer.invoke(Background.IS_ENCRYPTION_AVAILABLE);
   },
+  async getVersionStatus(): Promise<string> {
+    return await ipcRenderer.invoke(Background.GET_VERSION_STATUS);
+  },
+  sendTestNotification(): void {
+    ipcRenderer.send(Background.SEND_TEST_NOTIFICATION);
+  },
   openLogFile(logType: LogType): void {
     ipcRenderer.invoke(Background.OPEN_LOG_FILE, logType);
   },

--- a/src/renderer/ipc/web.ts
+++ b/src/renderer/ipc/web.ts
@@ -11,6 +11,7 @@ import { defaultCSAGameSettingHistory } from "@/common/settings/csa";
 import { defaultMateSearchSetting } from "@/common/settings/mate";
 import { defaultBatchConversionSetting } from "@/common/settings/conversion";
 import { getEmptyHistory } from "@/common/file/history";
+import { VersionStatus } from "@/background/version/types";
 
 enum STORAGE_KEY {
   APP_SETTING = "appSetting",
@@ -246,6 +247,12 @@ export const webAPI: Bridge = {
   },
   async isEncryptionAvailable(): Promise<boolean> {
     return false;
+  },
+  async getVersionStatus(): Promise<string> {
+    return JSON.stringify({} as VersionStatus);
+  },
+  sendTestNotification(): void {
+    throw new Error(t.thisFeatureNotAvailableOnWebApp);
   },
   openLogFile(): void {
     // Do Nothing


### PR DESCRIPTION
# 説明 / Description

アプリ設定ダイアログにアプリバージョンと通知に関する項目を表示する。
設定項目というわけでもないが、他に適当な設置場所がないのでとりあえずアプリ設定の中に置いてしまう。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
