### PR TITLE
Remove unused custom scheme privilege

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,7 +1,7 @@
 "use strict";
 
 import path from "node:path";
-import { app, protocol, BrowserWindow, session } from "electron";
+import { app, BrowserWindow, session } from "electron";
 import {
   getAppState,
   isClosable,
@@ -39,11 +39,6 @@ getAppLogger().info("process argv: %s", process.argv.join(" "));
 if (isPortable()) {
   getAppLogger().info("portable mode: %s", getPortableExeDir());
 }
-
-// Scheme must be registered before the app is ready
-protocol.registerSchemesAsPrivileged([
-  { scheme: "app", privileges: { secure: true, standard: true } },
-]);
 
 setLanguage(loadAppSettingOnce().language);
 


### PR DESCRIPTION
# 説明 / Description

初期に vue-cli で作った時のカスタムスキーマ `app` に関するコードが残っていたので除去する。
現在は `http` か `file` のどちらかしか使っていない。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
