### PR TITLE
Add coverage.exclude option

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -25,5 +25,17 @@ export default defineConfig({
     dir: "./src/tests",
     globals: true,
     environment: "jsdom",
+    coverage: {
+      exclude: [
+        "docs",
+        "plugins",
+        "scripts",
+        "src/tests",
+        "vite.config.ts",
+        ".*.*",
+        "**/*.d.ts",
+        "**/*.vue",
+      ],
+    },
   },
 });


### PR DESCRIPTION
# 説明 / Description

Vitest のバージョンを上げたタイミングから急激にカバレッジが下がっている。
どうやらスクリプトやプラグインを含めたすべてのファイルが対象になっているらしく、 exclude オプションで除外するよう修正する。

<img width="1289" alt="スクリーンショット 2024-01-04 19 25 37" src="https://github.com/sunfish-shogi/electron-shogi/assets/6257462/0ef1066e-9ec2-4c69-9e0b-469e1f2f0422">


# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
