### PR TITLE
CSA プロトコルに Keepalive と空行送信に関する設定を追加

### DIFF
--- a/src/background/csa/socket.ts
+++ b/src/background/csa/socket.ts
@@ -9,11 +9,20 @@ type SocketHandlers = {
   onRead(line: string): void;
 };
 
+type SocketOptions = {
+  keepaliveInitialDelay: number;
+};
+
 export class Socket {
   private socket: net.Socket;
   private readline: Readline | null;
 
-  constructor(host: string, port: number, handlers: SocketHandlers) {
+  constructor(
+    host: string,
+    port: number,
+    handlers: SocketHandlers,
+    options: SocketOptions = { keepaliveInitialDelay: 0 },
+  ) {
     this.socket = net
       .createConnection(
         {
@@ -22,7 +31,7 @@ export class Socket {
         },
         handlers.onConnect,
       )
-      .setKeepAlive(true)
+      .setKeepAlive(true, options.keepaliveInitialDelay * 1e3)
       .on("error", handlers.onError)
       .on("end", handlers.onFIN)
       .on("close", (hadError) => {

--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -105,6 +105,10 @@ export const en: Texts = {
   portNumber: "Port",
   password: "Password",
   showPassword: "Show Password",
+  keepaliveInitialDelay: "Keepalive Initial Delay",
+  blankLinePing: "Blank Line Ping",
+  blankLinePingInitialDelay: "Blank Line Ping Initial Delay",
+  blankLinePingInterval: "Blank Line Ping Interval",
   logout: "Logout",
   calculateJishogiPoints: "Calculate Jishogi Points",
   jishogiPoints: "Jishogi Points",
@@ -515,6 +519,10 @@ export const en: Texts = {
   hostNameIsEmpty: "Host name is empty.",
   invalidPortNumber: "Invalid port number.",
   idIsEmpty: "ID is empty.",
+  tcpKeepaliveInitialDelayMustBePositive: "TCP keepalive initial delay must be positive.",
+  blankLinePingInitialDelayMustBeGreaterThanOrEqualTo30:
+    "Blank line ping initial delay must be >=30.",
+  blankLinePingIntervalMustBeGreaterThanOrEqualTo30: "Blank line ping interval must be >=30.",
   engineNotSelected: "Engine is not selected.",
   forExportingConversionLogPleaseEnableAppLogsAndSetLogLevelDebugAndRestart:
     "For exporting conversion log, please enable app logs, set log level to DEBUG and restart this app.",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -104,6 +104,10 @@ export const ja: Texts = {
   portNumber: "ポート番号",
   password: "パスワード",
   showPassword: "パスワードを表示する",
+  keepaliveInitialDelay: "Keepalive初期遅延",
+  blankLinePing: "空行Ping",
+  blankLinePingInitialDelay: "空行Ping初期遅延",
+  blankLinePingInterval: "空行Ping間隔",
   logout: "ログアウト",
   calculateJishogiPoints: "持将棋の点数を計算",
   jishogiPoints: "持将棋の点数",
@@ -511,6 +515,12 @@ export const ja: Texts = {
   hostNameIsEmpty: "ホスト名が空です。",
   invalidPortNumber: "無効なポート番号です。",
   idIsEmpty: "IDが空です。",
+  tcpKeepaliveInitialDelayMustBePositive:
+    "TCP Keepaliveの初期遅延時間には正の値を指定してください。",
+  blankLinePingInitialDelayMustBeGreaterThanOrEqualTo30:
+    "空行送信の初期遅延時間には30秒以上を指定してください。",
+  blankLinePingIntervalMustBeGreaterThanOrEqualTo30:
+    "空行送信の間隔には30秒以上を指定してください。",
   engineNotSelected: "エンジンが選択されていません。",
   forExportingConversionLogPleaseEnableAppLogsAndSetLogLevelDebugAndRestart:
     "変換ログを出力するにはアプリログを有効にし、ログレベルをデバッグに設定してアプリを再起動してください。",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -104,6 +104,10 @@ export const zh_tw: Texts = {
   portNumber: "連接埠號碼",
   password: "密碼",
   showPassword: "顯示密碼",
+  keepaliveInitialDelay: "Keepalive初期遅延", // TODO: translate
+  blankLinePing: "空行Ping", // TODO: translate
+  blankLinePingInitialDelay: "空行Ping初期遅延", // TODO: translate
+  blankLinePingInterval: "空行Ping間隔", // TODO: translate
   logout: "登出",
   calculateJishogiPoints: "持将棋の点数を計算", // TODO: translate
   jishogiPoints: "持将棋の点数", // TODO: translate
@@ -505,6 +509,11 @@ export const zh_tw: Texts = {
   hostNameIsEmpty: "主機名稱為空。",
   invalidPortNumber: "不可用的連接埠號碼。",
   idIsEmpty: "ID 為空。",
+  tcpKeepaliveInitialDelayMustBePositive:
+    "TCP Keepaliveの初期遅延時間には正の値を指定してください。", // TODO: translate
+  blankLinePingInitialDelayMustBeGreaterThanOrEqualTo30:
+    "空行送信の初期遅延時間には正の値を指定してください。", // TODO: translate
+  blankLinePingIntervalMustBeGreaterThanOrEqualTo30: "空行送信の間隔には正の値を指定してください。", // TODO: translate
   engineNotSelected: "尚未選擇引擎。",
   forExportingConversionLogPleaseEnableAppLogsAndSetLogLevelDebugAndRestart:
     "如要監看轉換紀錄，請在程式設定內設定 log level 到 Debug 並重新啟動本程式。",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -102,6 +102,10 @@ export type Texts = {
   portNumber: string;
   password: string;
   showPassword: string;
+  keepaliveInitialDelay: string;
+  blankLinePing: string;
+  blankLinePingInitialDelay: string;
+  blankLinePingInterval: string;
   logout: string;
   calculateJishogiPoints: string;
   jishogiPoints: string;
@@ -498,6 +502,9 @@ export type Texts = {
   hostNameIsEmpty: string;
   invalidPortNumber: string;
   idIsEmpty: string;
+  tcpKeepaliveInitialDelayMustBePositive: string;
+  blankLinePingInitialDelayMustBeGreaterThanOrEqualTo30: string;
+  blankLinePingIntervalMustBeGreaterThanOrEqualTo30: string;
   engineNotSelected: string;
   forExportingConversionLogPleaseEnableAppLogsAndSetLogLevelDebugAndRestart: string;
   sourceDirectoryNotSpecified: string;

--- a/src/renderer/view/dialog/CSAGameDialog.vue
+++ b/src/renderer/view/dialog/CSAGameDialog.vue
@@ -119,6 +119,59 @@
             </div>
           </div>
           <div class="form-item">
+            <div class="form-item-label-wide">{{ t.keepaliveInitialDelay }}</div>
+            <input
+              ref="keepaliveInitialDelay"
+              class="number"
+              type="number"
+              value="10"
+              min="1"
+              max="7200"
+            />
+            <div class="form-item-small-label">
+              {{ t.secondsSuffix }} ({{ t.between(1, 7200) }})
+            </div>
+          </div>
+          <div class="form-item">
+            <div class="form-item-label-wide">{{ t.blankLinePing }}</div>
+            <ToggleButton
+              :value="blankLinePing"
+              @change="
+                (value: boolean) => {
+                  blankLinePing = value;
+                }
+              "
+            />
+          </div>
+          <div class="form-item" :class="{ hidden: !blankLinePing }">
+            <div class="form-item-label-wide">{{ t.blankLinePingInitialDelay }}</div>
+            <input
+              ref="blankLineInitialDelay"
+              class="number"
+              type="number"
+              value="40"
+              min="30"
+              max="7200"
+            />
+            <div class="form-item-small-label">
+              {{ t.secondsSuffix }} ({{ t.between(30, 7200) }})
+            </div>
+          </div>
+          <div class="form-item" :class="{ hidden: !blankLinePing }">
+            <div class="form-item-label-wide">{{ t.blankLinePingInterval }}</div>
+            <input
+              ref="blankLineInterval"
+              class="number"
+              type="number"
+              value="40"
+              min="30"
+              max="7200"
+            />
+            <div class="form-item-small-label">
+              {{ t.secondsSuffix }} ({{ t.between(30, 7200) }})
+            </div>
+          </div>
+          <div class="form-item">
             <div class="form-item-label-wide">{{ t.saveHistory }}</div>
             <ToggleButton
               :value="saveHistory"
@@ -230,6 +283,10 @@ const host = ref();
 const port = ref();
 const id = ref();
 const password = ref();
+const keepaliveInitialDelay = ref();
+const blankLinePing = ref(false);
+const blankLineInitialDelay = ref();
+const blankLineInterval = ref();
 const saveHistory = ref(true);
 const repeat = ref();
 const autoRelogin = ref(false);
@@ -277,6 +334,10 @@ onUpdated(() => {
   port.value.value = defaultSetting.server.port;
   id.value.value = defaultSetting.server.id;
   password.value.value = defaultSetting.server.password;
+  keepaliveInitialDelay.value.value = defaultSetting.server.tcpKeepalive.initialDelay;
+  blankLinePing.value = !!defaultSetting.server.blankLinePing;
+  blankLineInitialDelay.value.value = defaultSetting.server.blankLinePing?.initialDelay || 40;
+  blankLineInterval.value.value = defaultSetting.server.blankLinePing?.interval || 40;
   repeat.value.value = defaultSetting.repeat;
   autoRelogin.value = defaultSetting.autoRelogin;
   restartPlayerEveryGame.value = defaultSetting.restartPlayerEveryGame;
@@ -311,6 +372,15 @@ const onStart = () => {
       port: Number(port.value.value),
       id: String(id.value.value || ""),
       password: String(password.value.value || ""),
+      tcpKeepalive: {
+        initialDelay: readInputAsNumber(keepaliveInitialDelay.value),
+      },
+      blankLinePing: blankLinePing.value
+        ? {
+            initialDelay: readInputAsNumber(blankLineInitialDelay.value),
+            interval: readInputAsNumber(blankLineInterval.value),
+          }
+        : undefined,
     },
     repeat: readInputAsNumber(repeat.value),
     autoRelogin: autoRelogin.value,
@@ -354,6 +424,12 @@ const onChangeHistory = (event: Event) => {
     port.value.value = server.port;
     id.value.value = server.id;
     password.value.value = server.password;
+    keepaliveInitialDelay.value.value = server.tcpKeepalive.initialDelay;
+    blankLinePing.value = !!server.blankLinePing;
+    if (server.blankLinePing) {
+      blankLineInitialDelay.value.value = server.blankLinePing.initialDelay;
+      blankLineInterval.value.value = server.blankLinePing.interval;
+    }
   }
 };
 

--- a/src/tests/common/settings/csa.spec.ts
+++ b/src/tests/common/settings/csa.spec.ts
@@ -22,6 +22,7 @@ describe("settings/csa", () => {
         port: 4081,
         id: "TestUser",
         password: "test0123",
+        tcpKeepalive: { initialDelay: 10 },
       },
       autoFlip: true,
       enableComment: true,
@@ -45,6 +46,7 @@ describe("settings/csa", () => {
         port: 4081,
         id: "TestUser",
         password: "test0123",
+        tcpKeepalive: { initialDelay: 10 },
       },
       autoFlip: true,
       enableComment: true,
@@ -68,6 +70,7 @@ describe("settings/csa", () => {
         port: 100000,
         id: "TestUser",
         password: "test0123",
+        tcpKeepalive: { initialDelay: 10 },
       },
       autoFlip: true,
       enableComment: true,
@@ -91,6 +94,7 @@ describe("settings/csa", () => {
         port: 4081,
         id: "",
         password: "test0123",
+        tcpKeepalive: { initialDelay: 10 },
       },
       autoFlip: true,
       enableComment: true,
@@ -114,6 +118,7 @@ describe("settings/csa", () => {
           host: "test-server",
           port: 1234,
           id: "test-user",
+          tcpKeepalive: { initialDelay: 10 },
         },
       ],
       autoFlip: false,
@@ -192,6 +197,7 @@ describe("settings/csa", () => {
           port: 4081,
           id: "user01",
           password: "test01",
+          tcpKeepalive: { initialDelay: 10 },
         },
         {
           protocolVersion: CSAProtocolVersion.V121,
@@ -199,6 +205,7 @@ describe("settings/csa", () => {
           port: 4081,
           id: "user02",
           password: "test02",
+          tcpKeepalive: { initialDelay: 10 },
         },
       ],
       autoFlip: true,
@@ -225,6 +232,9 @@ describe("settings/csa", () => {
           port: 4081,
           id: "user01",
           encryptedPassword: "xyz01",
+          tcpKeepalive: {
+            initialDelay: 10,
+          },
         },
         {
           protocolVersion: CSAProtocolVersion.V121,
@@ -232,6 +242,9 @@ describe("settings/csa", () => {
           port: 4081,
           id: "user02",
           encryptedPassword: "xyz02",
+          tcpKeepalive: {
+            initialDelay: 10,
+          },
         },
       ],
     });
@@ -245,6 +258,7 @@ describe("settings/csa", () => {
           port: 4081,
           id: "user01",
           password: "test01",
+          tcpKeepalive: { initialDelay: 10 },
         },
         {
           protocolVersion: CSAProtocolVersion.V121,
@@ -252,6 +266,7 @@ describe("settings/csa", () => {
           port: 4081,
           id: "user02",
           password: "test02",
+          tcpKeepalive: { initialDelay: 10 },
         },
       ],
     });
@@ -270,6 +285,7 @@ describe("settings/csa", () => {
           port: 4081,
           id: "user01",
           encryptedPassword: "xyz01",
+          tcpKeepalive: { initialDelay: 10 },
         },
         {
           protocolVersion: CSAProtocolVersion.V121,
@@ -277,6 +293,7 @@ describe("settings/csa", () => {
           port: 4081,
           id: "user02",
           encryptedPassword: "xyz02",
+          tcpKeepalive: { initialDelay: 10 },
         },
       ],
       autoFlip: true,
@@ -295,6 +312,7 @@ describe("settings/csa", () => {
           port: 4081,
           id: "user03",
           password: "test03",
+          tcpKeepalive: { initialDelay: 10 },
         },
         {
           protocolVersion: CSAProtocolVersion.V121,
@@ -302,6 +320,7 @@ describe("settings/csa", () => {
           port: 4081,
           id: "user04",
           password: "test04",
+          tcpKeepalive: { initialDelay: 10 },
         },
       ],
     };
@@ -322,6 +341,7 @@ describe("settings/csa", () => {
           port: 4081,
           id: "user01",
           password: "test01",
+          tcpKeepalive: { initialDelay: 10 },
         },
         {
           protocolVersion: CSAProtocolVersion.V121,
@@ -329,6 +349,7 @@ describe("settings/csa", () => {
           port: 4081,
           id: "user02",
           password: "test02",
+          tcpKeepalive: { initialDelay: 10 },
         },
       ],
     });
@@ -342,6 +363,7 @@ describe("settings/csa", () => {
           port: 4081,
           id: "user03",
           password: "test03",
+          tcpKeepalive: { initialDelay: 10 },
         },
         {
           protocolVersion: CSAProtocolVersion.V121,
@@ -349,6 +371,7 @@ describe("settings/csa", () => {
           port: 4081,
           id: "user04",
           password: "test04",
+          tcpKeepalive: { initialDelay: 10 },
         },
       ],
     });

--- a/src/tests/mock/csa.ts
+++ b/src/tests/mock/csa.ts
@@ -29,6 +29,7 @@ export const csaServerSetting: CSAServerSetting = {
   port: 4081,
   id: "TestPlayer",
   password: "test-password",
+  tcpKeepalive: { initialDelay: 10 },
 };
 
 export const csaGameSetting: CSAGameSetting = {
@@ -62,6 +63,7 @@ export const singleCSAGameSettingHistory: CSAGameSettingHistory = {
       port: 4081,
       id: "TestPlayer",
       password: "test-password",
+      tcpKeepalive: { initialDelay: 10 },
     },
   ],
   autoFlip: true,


### PR DESCRIPTION
# 説明 / Description

<img width="551" alt="スクリーンショット 2024-01-13 23 12 09" src="https://github.com/sunfish-shogi/electron-shogi/assets/6257462/bac941fa-86ef-44b5-b058-4a36e4ffd7f5">

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [x] i18n
