### PR TITLE
USI や CSA プロトコルにおいてマニュアル操作目的で接続する機能

### DIFF
--- a/src/background/csa/client.ts
+++ b/src/background/csa/client.ts
@@ -281,7 +281,11 @@ export class Client {
   private onConnect(): void {
     this.logger.info("sid=%d: connected", this.sessionID);
     this._state = State.CONNECTED;
-    this.send(`LOGIN ${this.setting.id} ${this.setting.password}`);
+    let suffix = "";
+    if (this.setting.protocolVersion === CSAProtocolVersion.V121_X1) {
+      suffix = " x1";
+    }
+    this.send(`LOGIN ${this.setting.id} ${this.setting.password}${suffix}`);
   }
 
   private onConnectionError(e: Error): void {

--- a/src/background/window/menu.ts
+++ b/src/background/window/menu.ts
@@ -378,6 +378,9 @@ function createMenuTemplate() {
           role: "toggleDevTools",
         },
         {
+          type: "separator",
+        },
+        {
           label: t.logFile,
           submenu: [
             {
@@ -444,6 +447,15 @@ function createMenuTemplate() {
               },
             },
           ],
+        },
+        menuItem(`${t.launchUSIEngine}(${t.adminMode})`, MenuEvent.LAUNCH_USI_ENGINE, [
+          AppState.NORMAL,
+        ]),
+        menuItem(`${t.connectToCSAServer}(${t.adminMode})`, MenuEvent.CONNECT_TO_CSA_SERVER, [
+          AppState.NORMAL,
+        ]),
+        {
+          type: "separator",
         },
         {
           label: t.reloadCustomPieceImage,

--- a/src/common/control/menu.ts
+++ b/src/common/control/menu.ts
@@ -48,4 +48,6 @@ export enum MenuEvent {
   FLIP_BOARD = "flipBoard",
   APP_SETTING_DIALOG = "appSetting",
   USI_ENGINE_SETTING_DIALOG = "usiEngineSetting",
+  LAUNCH_USI_ENGINE = "launchUsiEngine",
+  CONNECT_TO_CSA_SERVER = "connectToCsaServer",
 }

--- a/src/common/control/state.ts
+++ b/src/common/control/state.ts
@@ -16,4 +16,6 @@ export enum AppState {
   USI_ENGINE_SETTING_DIALOG = "usiEngineSettingDialog",
   RECORD_FILE_HISTORY_DIALOG = "recordFileHistoryDialog",
   BATCH_CONVERSION_DIALOG = "batchConversionDialog",
+  LAUNCH_USI_ENGINE_DIALOG = "launchUsiEngineDialog",
+  CONNECT_TO_CSA_SERVER_DIALOG = "connectToCsaServerDialog",
 }

--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -58,6 +58,14 @@ export const en: Texts = {
   copyUSILogTailCommand: "Copy USI Log Tail Command",
   copyCSALogTailCommand: "Copy CSA Log Tail Command",
   reloadCustomPieceImage: "Reload Custom Piece Image",
+  launchUSIEngine: "Launch USI Engine",
+  connectToCSAServer: "Connect to CSA Server",
+  adminMode: "Admin Mode",
+  inAdminModeYouShouldInvokeCommandsManuallyAtPrompt:
+    "In admin mode, you should invoke commands manually at prompt.",
+  setoptionAndPrecedingCommandsWillBeSentAutomatically:
+    '"setoption" and preceding commands will be sent automatically.',
+  serverMustSupportShogiServerX1ModeLogIn: "The server must support shogi-server's x1-mode log-in.",
   folders: "Folders",
   notification: "Notification",
   notificationTest: "Notification Test",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -57,6 +57,15 @@ export const ja: Texts = {
   copyUSILogTailCommand: "USI通信ログのTailコマンドをコピー",
   copyCSALogTailCommand: "CSA通信ログのTailコマンドをコピー",
   reloadCustomPieceImage: "カスタム駒画像をリロード",
+  launchUSIEngine: "USIエンジンを起動",
+  connectToCSAServer: "CSAサーバーに接続",
+  adminMode: "管理モード",
+  inAdminModeYouShouldInvokeCommandsManuallyAtPrompt:
+    "管理モードではプロンプトから手動でコマンドを実行する必要があります。",
+  setoptionAndPrecedingCommandsWillBeSentAutomatically:
+    "setoptionコマンドまでのコマンドは自動で送信されます。",
+  serverMustSupportShogiServerX1ModeLogIn:
+    "サーバーは shogi-server の拡張モード (x1) ログインをサポートしている必要があります。",
   folders: "各種フォルダ",
   notification: "通知",
   notificationTest: "通知テスト",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -57,6 +57,15 @@ export const zh_tw: Texts = {
   copyUSILogTailCommand: "USI通信ログのTailコマンドをコピー", // TODO: translate
   copyCSALogTailCommand: "CSA通信ログのTailコマンドをコピー", // TODO: translate
   reloadCustomPieceImage: "カスタム駒画像をリロード", // TODO: translate
+  launchUSIEngine: "USIエンジンを起動", // TODO: translate
+  connectToCSAServer: "CSAサーバーに接続", // TODO: translate
+  adminMode: "管理モード", // TODO: translate
+  inAdminModeYouShouldInvokeCommandsManuallyAtPrompt:
+    "管理モードではプロンプトから手動でコマンドを実行する必要があります。", // TODO: translate
+  setoptionAndPrecedingCommandsWillBeSentAutomatically:
+    "setoptionコマンドまでのコマンドは自動で送信されます。", // TODO: translate
+  serverMustSupportShogiServerX1ModeLogIn:
+    "サーバーは shogi-server の拡張モード (x1) ログインをサポートしている必要があります。", // TODO: translate
   folders: "各種フォルダ", // TODO: translate
   notification: "通知", // TODO: translate
   notificationTest: "通知テスト", // TODO: translate

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -55,6 +55,12 @@ export type Texts = {
   copyUSILogTailCommand: string;
   copyCSALogTailCommand: string;
   reloadCustomPieceImage: string;
+  launchUSIEngine: string;
+  connectToCSAServer: string;
+  adminMode: string;
+  inAdminModeYouShouldInvokeCommandsManuallyAtPrompt: string;
+  setoptionAndPrecedingCommandsWillBeSentAutomatically: string;
+  serverMustSupportShogiServerX1ModeLogIn: string;
   folders: string;
   notification: string;
   notificationTest: string;

--- a/src/common/settings/csa.ts
+++ b/src/common/settings/csa.ts
@@ -5,6 +5,7 @@ import { t } from "@/common/i18n";
 export enum CSAProtocolVersion {
   V121 = "v121",
   V121_FLOODGATE = "v121_floodgate",
+  V121_X1 = "v121_x1",
 }
 
 export type TCPKeepaliveSetting = {

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -12,6 +12,8 @@
     <PositionImageExportDialog v-if="store.appState === AppState.EXPORT_POSITION_IMAGE_DIALOG" />
     <AppSettingDialog v-if="store.isAppSettingDialogVisible" />
     <PasteDialog v-if="store.appState === AppState.PASTE_DIALOG" />
+    <LaunchUSIEngineDialog v-if="store.appState === AppState.LAUNCH_USI_ENGINE_DIALOG" />
+    <ConnectToCSAServerDialog v-if="store.appState === AppState.CONNECT_TO_CSA_SERVER_DIALOG" />
     <BussyMessage v-if="store.isBussy" />
     <ConfirmDialog v-if="store.confirmation" />
     <CSAGameReadyDialog
@@ -65,6 +67,8 @@ import MateSearchDialog from "./view/dialog/MateSearchDialog.vue";
 import PVPreviewDialog from "./view/dialog/PVPreviewDialog.vue";
 import RecordFileHistoryDialog from "./view/dialog/RecordFileHistoryDialog.vue";
 import BatchConversionDialog from "./view/dialog/BatchConversionDialog.vue";
+import LaunchUSIEngineDialog from "./view/dialog/LaunchUSIEngineDialog.vue";
+import ConnectToCSAServerDialog from "./view/dialog/ConnectToCSAServerDialog.vue";
 
 const appSetting = useAppSetting();
 const store = useStore();

--- a/src/renderer/ipc/setup.ts
+++ b/src/renderer/ipc/setup.ts
@@ -213,6 +213,12 @@ export function setup(): void {
       case MenuEvent.USI_ENGINE_SETTING_DIALOG:
         store.showUsiEngineManagementDialog();
         break;
+      case MenuEvent.LAUNCH_USI_ENGINE:
+        store.showLaunchUSIEngineDialog();
+        break;
+      case MenuEvent.CONNECT_TO_CSA_SERVER:
+        store.showConnectToCSAServerDialog();
+        break;
     }
   });
   bridge.updateAppSetting((json: string) => {

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -356,6 +356,18 @@ class Store {
     }
   }
 
+  showLaunchUSIEngineDialog(): void {
+    if (this.appState === AppState.NORMAL) {
+      this._appState = AppState.LAUNCH_USI_ENGINE_DIALOG;
+    }
+  }
+
+  showConnectToCSAServerDialog(): void {
+    if (this.appState === AppState.NORMAL) {
+      this._appState = AppState.CONNECT_TO_CSA_SERVER_DIALOG;
+    }
+  }
+
   destroyModalDialog(): void {
     if (
       this.appState === AppState.PASTE_DIALOG ||
@@ -367,7 +379,9 @@ class Store {
       this.appState === AppState.USI_ENGINE_SETTING_DIALOG ||
       this.appState === AppState.EXPORT_POSITION_IMAGE_DIALOG ||
       this.appState === AppState.RECORD_FILE_HISTORY_DIALOG ||
-      this.appState === AppState.BATCH_CONVERSION_DIALOG
+      this.appState === AppState.BATCH_CONVERSION_DIALOG ||
+      this.appState === AppState.LAUNCH_USI_ENGINE_DIALOG ||
+      this.appState === AppState.CONNECT_TO_CSA_SERVER_DIALOG
     ) {
       this._appState = AppState.NORMAL;
     }

--- a/src/renderer/view/dialog/AnalysisDialog.vue
+++ b/src/renderer/view/dialog/AnalysisDialog.vue
@@ -149,7 +149,7 @@ onBeforeUnmount(() => {
 
 const onStart = () => {
   if (!engineURI.value || !engineSettings.value.hasEngine(engineURI.value)) {
-    store.pushError("エンジンを選択してください。");
+    store.pushError(t.engineNotSelected);
     return;
   }
   const engine = engineSettings.value.getEngine(engineURI.value);

--- a/src/renderer/view/dialog/CSAGameDialog.vue
+++ b/src/renderer/view/dialog/CSAGameDialog.vue
@@ -83,6 +83,7 @@
               <option value="gserver.computer-shogi.org"></option>
               <option value="wdoor.c.u-tokyo.ac.jp"></option>
               <option value="localhost"></option>
+              <option value="127.0.0.1"></option>
             </datalist>
           </div>
           <div class="form-item">

--- a/src/renderer/view/dialog/ConnectToCSAServerDialog.vue
+++ b/src/renderer/view/dialog/ConnectToCSAServerDialog.vue
@@ -1,0 +1,122 @@
+<template>
+  <div>
+    <dialog ref="dialog" class="root">
+      <div class="title">{{ t.connectToCSAServer }}({{ t.adminMode }})</div>
+      <div class="form-group">
+        <div class="form-item">
+          <div class="form-item-label-wide">{{ t.hostToConnect }}</div>
+          <input ref="host" class="long-text" list="csa-server-host" type="text" />
+          <datalist id="csa-server-host">
+            <option value="gserver.computer-shogi.org"></option>
+            <option value="wdoor.c.u-tokyo.ac.jp"></option>
+            <option value="localhost"></option>
+            <option value="127.0.0.1"></option>
+          </datalist>
+        </div>
+        <div class="form-item">
+          <div class="form-item-label-wide">{{ t.portNumber }}</div>
+          <input
+            ref="port"
+            class="number"
+            list="csa-server-port-number"
+            type="number"
+            value="4081"
+          />
+          <datalist id="csa-server-port-number">
+            <option value="4081"></option>
+          </datalist>
+        </div>
+        <div class="form-item">
+          <div class="form-item-label-wide">ID</div>
+          <input ref="id" class="long-text" type="text" value="admin" />
+        </div>
+        <div class="form-item">
+          <div class="form-item-label-wide">{{ t.password }}</div>
+          <input ref="password" class="long-text" type="password" />
+        </div>
+        <div class="form-item">
+          <div class="form-item-label-wide"></div>
+          <ToggleButton
+            :label="t.showPassword"
+            :value="false"
+            @change="onTogglePasswordVisibility"
+          />
+        </div>
+      </div>
+      <div class="form-group warning">
+        <div class="note">
+          {{ t.inAdminModeYouShouldInvokeCommandsManuallyAtPrompt }}
+        </div>
+      </div>
+      <div class="main-buttons">
+        <button data-hotkey="Enter" autofocus @click="onStart()">
+          {{ t.startGame }}
+        </button>
+        <button data-hotkey="Escape" @click="onCancel()">
+          {{ t.cancel }}
+        </button>
+      </div>
+    </dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { PromptTarget } from "@/common/advanced/prompt";
+import { t } from "@/common/i18n";
+import { CSAProtocolVersion } from "@/common/settings/csa";
+import { installHotKeyForDialog, uninstallHotKeyForDialog } from "@/renderer/devices/hotkey";
+import { showModalDialog } from "@/renderer/helpers/dialog";
+import api from "@/renderer/ipc/api";
+import { useStore } from "@/renderer/store";
+import { onBeforeUnmount, onMounted, ref } from "vue";
+import ToggleButton from "@/renderer/view/primitive/ToggleButton.vue";
+import { useAppSetting } from "@/renderer/store/setting";
+import { Tab } from "@/common/settings/app";
+
+const store = useStore();
+const dialog = ref();
+const host = ref();
+const port = ref();
+const id = ref();
+const password = ref();
+
+onMounted(() => {
+  showModalDialog(dialog.value);
+  installHotKeyForDialog(dialog.value);
+});
+
+onBeforeUnmount(() => {
+  uninstallHotKeyForDialog(dialog.value);
+});
+
+const onTogglePasswordVisibility = (value: boolean) => {
+  password.value.type = value ? "text" : "password";
+};
+
+const onStart = async () => {
+  const setting = {
+    protocolVersion: CSAProtocolVersion.V121_X1,
+    host: host.value.value,
+    port: port.value.value,
+    id: id.value.value,
+    password: password.value.value,
+    tcpKeepalive: {
+      initialDelay: 60,
+    },
+  };
+  const sessionID = await api.csaLogin(setting);
+  api.openPrompt(PromptTarget.CSA, sessionID, `${setting.host}:${setting.port}`);
+  useAppSetting().updateAppSetting({ tab: Tab.MONITOR });
+  store.closeModalDialog();
+};
+
+const onCancel = () => {
+  store.closeModalDialog();
+};
+</script>
+
+<style scoped>
+.root {
+  width: 560px;
+}
+</style>

--- a/src/renderer/view/dialog/LaunchUSIEngineDialog.vue
+++ b/src/renderer/view/dialog/LaunchUSIEngineDialog.vue
@@ -1,0 +1,106 @@
+<template>
+  <div>
+    <dialog ref="dialog" class="root">
+      <div class="title">{{ t.launchUSIEngine }}({{ t.adminMode }})</div>
+      <div class="form-group">
+        <div>{{ t.searchEngine }}</div>
+        <PlayerSelector
+          :player-uri="engineURI"
+          :engine-settings="engineSettings"
+          :display-thread-state="true"
+          :display-multi-pv-state="true"
+          @update-engine-setting="onUpdatePlayerSetting"
+          @select-player="onSelectPlayer"
+        />
+      </div>
+      <div class="form-group warning">
+        <div class="note">
+          {{ t.inAdminModeYouShouldInvokeCommandsManuallyAtPrompt }}
+        </div>
+        <div class="note">
+          {{ t.serverMustSupportShogiServerX1ModeLogIn }}
+        </div>
+        <div class="note">
+          {{ t.setoptionAndPrecedingCommandsWillBeSentAutomatically }}
+        </div>
+      </div>
+      <div class="main-buttons">
+        <button data-hotkey="Enter" autofocus @click="onStart()">
+          {{ t.startGame }}
+        </button>
+        <button data-hotkey="Escape" @click="onCancel()">
+          {{ t.cancel }}
+        </button>
+      </div>
+    </dialog>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { t } from "@/common/i18n";
+import { installHotKeyForDialog, uninstallHotKeyForDialog } from "@/renderer/devices/hotkey";
+import { showModalDialog } from "@/renderer/helpers/dialog";
+import { useStore } from "@/renderer/store";
+import { onBeforeUnmount, onMounted, ref } from "vue";
+import PlayerSelector from "./PlayerSelector.vue";
+import { USIEngineSettings } from "@/common/settings/usi";
+import api from "@/renderer/ipc/api";
+import { useAppSetting } from "@/renderer/store/setting";
+import { PromptTarget } from "@/common/advanced/prompt";
+import { Tab } from "@/common/settings/app";
+
+const store = useStore();
+const appSetting = useAppSetting();
+const dialog = ref();
+const engineSettings = ref(new USIEngineSettings());
+const engineURI = ref("");
+
+store.retainBussyState();
+
+onMounted(async () => {
+  showModalDialog(dialog.value);
+  installHotKeyForDialog(dialog.value);
+  try {
+    engineSettings.value = await api.loadUSIEngineSetting();
+  } catch (e) {
+    store.pushError(e);
+    store.destroyModalDialog();
+  } finally {
+    store.releaseBussyState();
+  }
+});
+
+onBeforeUnmount(() => {
+  uninstallHotKeyForDialog(dialog.value);
+});
+
+const onStart = async () => {
+  const setting = engineSettings.value.getEngine(engineURI.value);
+  if (!setting) {
+    store.pushError(t.engineNotSelected);
+    return;
+  }
+  const sessionID = await api.usiLaunch(setting, appSetting.engineTimeoutSeconds);
+  api.openPrompt(PromptTarget.USI, sessionID, setting.name);
+  useAppSetting().updateAppSetting({ tab: Tab.MONITOR });
+  store.closeModalDialog();
+};
+
+const onCancel = () => {
+  store.closeModalDialog();
+};
+
+const onUpdatePlayerSetting = async (settings: USIEngineSettings) => {
+  engineSettings.value = settings;
+};
+
+const onSelectPlayer = (uri: string) => {
+  engineURI.value = uri;
+};
+</script>
+
+<style scoped>
+.root {
+  width: 560px;
+}
+</style>

--- a/src/renderer/view/dialog/PlayerSelector.vue
+++ b/src/renderer/view/dialog/PlayerSelector.vue
@@ -81,7 +81,7 @@ const props = defineProps({
   },
   filterLabel: {
     type: String as PropType<USIEngineLabel>,
-    required: true,
+    default: null,
   },
   displayPonderState: {
     type: Boolean,
@@ -107,7 +107,9 @@ const playerSelect = ref();
 const engineSettingDialog = ref(null as USIEngineSetting | null);
 
 const filteredEngineSettings = computed(() => {
-  return props.engineSettings.filterByLabel(props.filterLabel);
+  return props.filterLabel
+    ? props.engineSettings.filterByLabel(props.filterLabel)
+    : props.engineSettings;
 });
 
 const ponderState = computed(() => {


### PR DESCRIPTION
# 説明 / Description

対局や検討などの機能から USI や CSA のセッションを作るのではなく、セッションの確立だけを行ってプロンプトからマニュアルでコマンド実行する機能を追加する。
後から対局や検討に使用することはできず、あくまでも管理やテストの目的で使用するためのもの。
例えば shogi-server に接続して BUOY の設定をする際に利用する。

<img width="364" alt="スクリーンショット 2024-01-14 21 43 40" src="https://github.com/sunfish-shogi/electron-shogi/assets/6257462/0c8b222c-1de4-4f9d-8a63-9cf1116380a5">

関連: #679 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [x] i18n
