### PR TITLE
Fix hotkey action

### DIFF
--- a/src/renderer/view/menu/FileMenu.vue
+++ b/src/renderer/view/menu/FileMenu.vue
@@ -3,7 +3,7 @@
     <dialog ref="dialog" class="menu">
       <div class="groups">
         <div class="group">
-          <button class="close" @click="onClose">
+          <button data-hotkey="Escape" class="close" @click="onClose">
             <Icon :icon="IconType.CLOSE" />
             <div class="label">{{ t.back }}</div>
           </button>
@@ -82,13 +82,14 @@
 <script setup lang="ts">
 import { t } from "@/common/i18n";
 import { showModalDialog } from "@/renderer/helpers/dialog.js";
-import { computed, onMounted, ref } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 import Icon from "@/renderer/view/primitive/Icon.vue";
 import { IconType } from "@/renderer/assets/icons";
 import { useStore } from "@/renderer/store";
 import { AppState } from "@/common/control/state.js";
 import api from "@/renderer/ipc/api";
 import { useAppSetting } from "@/renderer/store/setting";
+import { installHotKeyForDialog, uninstallHotKeyForDialog } from "@/renderer/devices/hotkey";
 
 const emit = defineEmits<{
   close: [];
@@ -102,6 +103,10 @@ const onClose = () => {
 };
 onMounted(() => {
   showModalDialog(dialog.value, onClose);
+  installHotKeyForDialog(dialog.value);
+});
+onBeforeUnmount(() => {
+  uninstallHotKeyForDialog(dialog.value);
 });
 const onNewFile = () => {
   store.resetRecord();

--- a/src/renderer/view/menu/GameMenu.vue
+++ b/src/renderer/view/menu/GameMenu.vue
@@ -3,7 +3,7 @@
     <dialog ref="dialog" class="menu">
       <div class="groups">
         <div class="group">
-          <button class="close" @click="onClose">
+          <button data-hotkey="Escape" class="close" @click="onClose">
             <Icon :icon="IconType.CLOSE" />
             <div class="label">{{ t.back }}</div>
           </button>
@@ -26,10 +26,11 @@
 <script setup lang="ts">
 import { t } from "@/common/i18n";
 import { showModalDialog } from "@/renderer/helpers/dialog.js";
-import { onMounted, ref } from "vue";
+import { onBeforeUnmount, onMounted, ref } from "vue";
 import Icon from "@/renderer/view/primitive/Icon.vue";
 import { IconType } from "@/renderer/assets/icons";
 import { useStore } from "@/renderer/store";
+import { installHotKeyForDialog, uninstallHotKeyForDialog } from "@/renderer/devices/hotkey";
 
 const emit = defineEmits<{
   close: [];
@@ -42,6 +43,10 @@ const onClose = () => {
 };
 onMounted(() => {
   showModalDialog(dialog.value, onClose);
+  installHotKeyForDialog(dialog.value);
+});
+onBeforeUnmount(() => {
+  uninstallHotKeyForDialog(dialog.value);
 });
 const onLocalGame = () => {
   store.showGameDialog();

--- a/src/renderer/view/menu/InitialPositionMenu.vue
+++ b/src/renderer/view/menu/InitialPositionMenu.vue
@@ -3,7 +3,7 @@
     <dialog ref="dialog" class="menu">
       <div class="groups">
         <div class="group">
-          <button class="close" @click="onClose">
+          <button data-hotkey="Escape" class="close" @click="onClose">
             <Icon :icon="IconType.CLOSE" />
             <div class="label">{{ t.back }}</div>
           </button>
@@ -70,11 +70,12 @@
 <script setup lang="ts">
 import { t } from "@/common/i18n";
 import { showModalDialog } from "@/renderer/helpers/dialog.js";
-import { onMounted, ref } from "vue";
+import { onBeforeUnmount, onMounted, ref } from "vue";
 import Icon from "@/renderer/view/primitive/Icon.vue";
 import { IconType } from "@/renderer/assets/icons";
 import { useStore } from "@/renderer/store";
 import { InitialPositionSFEN } from "electron-shogi-core";
+import { installHotKeyForDialog, uninstallHotKeyForDialog } from "@/renderer/devices/hotkey";
 
 const emit = defineEmits<{
   close: [];
@@ -91,5 +92,9 @@ const onPush = (sfen: string) => {
 };
 onMounted(() => {
   showModalDialog(dialog.value, onClose);
+  installHotKeyForDialog(dialog.value);
+});
+onBeforeUnmount(() => {
+  uninstallHotKeyForDialog(dialog.value);
 });
 </script>


### PR DESCRIPTION
# 説明 / Description

#732 

メニュー表示中に Escape キーを押すと、ダイアログが閉じられずになぜか親の DOM にキーイベントが行ってしまうので、 google/hotkey で Escape を拾う形で対処する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
