### PR TITLE
Update to display irregular pv text

### DIFF
--- a/src/renderer/store/usi.ts
+++ b/src/renderer/store/usi.ts
@@ -22,14 +22,18 @@ function formatPV(position: ImmutablePosition, pv: string[]): string {
   const p = position.clone();
   let lastMove: Move | undefined;
   let result = "";
-  for (const usiMove of pv) {
-    const move = p.createMoveByUSI(usiMove);
+  let i = 0;
+  for (; i < pv.length; i++) {
+    const move = p.createMoveByUSI(pv[i]);
     if (!move) {
       break;
     }
     result += formatMove(p, move, { lastMove });
     p.doMove(move, { ignoreValidation: true });
     lastMove = move;
+  }
+  for (; i < pv.length; i++) {
+    result += " " + pv[i];
   }
   return result;
 }

--- a/src/tests/renderer/store/index.spec.ts
+++ b/src/tests/renderer/store/index.spec.ts
@@ -199,6 +199,7 @@ describe("store/index", () => {
     store.updateUSIInfo(101, usi, "Engine A", {
       depth: 8,
       scoreCP: 138,
+      pv: ["8c8d", "2g2f", "foo", "bar"],
     });
     vi.runOnlyPendingTimers();
     expect(store.usiMonitors).toHaveLength(1);
@@ -208,6 +209,8 @@ describe("store/index", () => {
     expect(store.usiMonitors[0].iterations.length).toBe(1);
     expect(store.usiMonitors[0].iterations[0].depth).toBe(8);
     expect(store.usiMonitors[0].iterations[0].score).toBe(138);
+    expect(store.usiMonitors[0].iterations[0].pv).toEqual(["8c8d", "2g2f", "foo", "bar"]);
+    expect(store.usiMonitors[0].iterations[0].text).toBe("☖８四歩☗２六歩 foo bar");
     store.updateUSIInfo(101, usi, "Engine A", {
       depth: 10,
       scoreCP: 213,


### PR DESCRIPTION
# 説明 / Description

#175

PV において、USI 形式でないかあるいは合法手ではない文字列が来た場合に、文字列をそのまま表示する。
 
<img width="761" alt="スクリーンショット 2024-01-21 20 32 32" src="https://github.com/sunfish-shogi/electron-shogi/assets/6257462/f10e1fd3-6a54-4a36-aea0-e3ab0c085180">

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [ ] i18n
