### PR TITLE
Add buffering to enhance prompt performance

### DIFF
--- a/src/background/csa/client.ts
+++ b/src/background/csa/client.ts
@@ -17,8 +17,7 @@ import { CSAProtocolVersion, CSAServerSetting } from "@/common/settings/csa";
 import { Socket } from "./socket";
 import { Logger } from "log4js";
 import { t } from "@/common/i18n";
-import { Command } from "@/common/advanced/command";
-import { PromptHistory, addCommand } from "@/common/advanced/prompt";
+import { Command, CommandHistory, addCommand, newCommand } from "@/common/advanced/command";
 import { CommandType } from "@/common/advanced/command";
 
 type GameSummaryCallback = (gameSummary: CSAGameSummary) => void;
@@ -47,8 +46,6 @@ export enum State {
   CLOSED = "closed",
 }
 
-const maxCommandHistoryLength = 100;
-
 export class Client {
   private _state: State = State.IDLE;
   private gameSummaryCallback?: GameSummaryCallback;
@@ -65,7 +62,7 @@ export class Client {
   private specialMove = CSASpecialMove.UNKNOWN;
   private _lastReceived?: Command;
   private _lastSent?: Command;
-  private _commandHistory: PromptHistory = {
+  private _commandHistory: CommandHistory = {
     discarded: 0,
     commands: [],
   };
@@ -95,7 +92,7 @@ export class Client {
     return this._lastSent;
   }
 
-  get commandHistory(): PromptHistory {
+  get commandHistory(): CommandHistory {
     return this._commandHistory;
   }
 
@@ -261,12 +258,8 @@ export class Client {
       return;
     }
     this.socket.write(command);
-    this._lastSent = {
-      type: CommandType.SEND,
-      command: this.hideSecureValues(command),
-      timeMs: Date.now(),
-    };
-    addCommand(this._commandHistory, this._lastSent, maxCommandHistoryLength);
+    this._lastSent = newCommand(CommandType.SEND, this.hideSecureValues(command));
+    this.updateCommendHistory(this._lastSent);
     if (this.commandCallback) {
       this.commandCallback(this._lastSent);
     }
@@ -297,12 +290,8 @@ export class Client {
     if (this.closeCallback) {
       this.closeCallback();
     }
-    const command = {
-      type: CommandType.SYSTEM,
-      command: "connection error",
-      timeMs: Date.now(),
-    };
-    addCommand(this._commandHistory, command, maxCommandHistoryLength);
+    const command = newCommand(CommandType.SYSTEM, "connection error");
+    this.updateCommendHistory(command);
     if (this.commandCallback) {
       this.commandCallback(command);
     }
@@ -346,12 +335,8 @@ export class Client {
     if (this.closeCallback) {
       this.closeCallback();
     }
-    const command = {
-      type: CommandType.SYSTEM,
-      command: hadError ? "closed (error)" : "closed",
-      timeMs: Date.now(),
-    };
-    addCommand(this._commandHistory, command, maxCommandHistoryLength);
+    const command = newCommand(CommandType.SYSTEM, hadError ? "closed (error)" : "closed");
+    this.updateCommendHistory(command);
     if (this.commandCallback) {
       this.commandCallback(command);
     }
@@ -359,12 +344,8 @@ export class Client {
 
   private onRead(command: string): void {
     this.setBlankLinePing();
-    this._lastReceived = {
-      type: CommandType.RECEIVE,
-      command,
-      timeMs: Date.now(),
-    };
-    addCommand(this._commandHistory, this._lastReceived, maxCommandHistoryLength);
+    this._lastReceived = newCommand(CommandType.RECEIVE, command);
+    this.updateCommendHistory(this._lastReceived);
     if (this.commandCallback) {
       this.commandCallback(this._lastReceived);
     }
@@ -678,5 +659,9 @@ export class Client {
       clearTimeout(this.blankLinePingTimeout);
       this.blankLinePingTimeout = null;
     }
+  }
+
+  private updateCommendHistory(command: Command): void {
+    addCommand(this._commandHistory, command, 100, 10);
   }
 }

--- a/src/background/csa/index.ts
+++ b/src/background/csa/index.ts
@@ -12,8 +12,8 @@ import {
 import { getCSALogger } from "@/background/log";
 import { Client, State } from "@/background/csa/client";
 import { CSASessionState } from "@/common/advanced/monitor";
-import { PromptHistory, PromptTarget } from "@/common/advanced/prompt";
-import { CommandType } from "@/common/advanced/command";
+import { PromptTarget } from "@/common/advanced/prompt";
+import { CommandHistory, CommandType } from "@/common/advanced/command";
 
 let lastSessionID = 0;
 
@@ -110,7 +110,7 @@ export function collectSessionStates(): CSASessionState[] {
     .sort((a, b) => b.sessionID - a.sessionID);
 }
 
-export function getCommandHistory(sessionID: number): PromptHistory {
+export function getCommandHistory(sessionID: number): CommandHistory {
   const client = clients.get(sessionID);
   if (client) {
     return client.commandHistory;

--- a/src/background/usi/index.ts
+++ b/src/background/usi/index.ts
@@ -17,8 +17,8 @@ import { t } from "@/common/i18n";
 import { resolveEnginePath } from "@/background/usi/path";
 import { getUSILogger } from "@/background/log";
 import { USISessionState } from "@/common/advanced/monitor";
-import { PromptHistory, PromptTarget } from "@/common/advanced/prompt";
-import { CommandType } from "@/common/advanced/command";
+import { PromptTarget } from "@/common/advanced/prompt";
+import { CommandHistory, CommandType } from "@/common/advanced/command";
 
 function newTimeoutError(timeoutSeconds: number): Error {
   return new Error(t.noResponseFromEnginePleaseExtendTimeout(timeoutSeconds));
@@ -272,7 +272,7 @@ export function collectSessionStates(): USISessionState[] {
     .sort((a, b) => b.sessionID - a.sessionID);
 }
 
-export function getCommandHistory(sessionID: number): PromptHistory {
+export function getCommandHistory(sessionID: number): CommandHistory {
   const session = getSession(sessionID);
   return session.process.commandHistory;
 }

--- a/src/common/advanced/command.ts
+++ b/src/common/advanced/command.ts
@@ -1,3 +1,5 @@
+import { getDateTimeStringMs } from "@/common/helpers/datetime";
+
 export enum CommandType {
   SEND = "send",
   RECEIVE = "receive",
@@ -7,5 +9,40 @@ export enum CommandType {
 export type Command = {
   type: CommandType;
   command: string;
+  dateTime: string;
   timeMs: number;
 };
+
+export function newCommand(type: CommandType, command: string): Command {
+  const date = new Date();
+  return {
+    type,
+    command,
+    dateTime: getDateTimeStringMs(date),
+    timeMs: date.getTime(),
+  };
+}
+
+export type CommandHistory<T = Command> = {
+  discarded: number;
+  commands: T[];
+};
+
+export function addCommand<T>(
+  history: CommandHistory<T>,
+  commands: T | T[],
+  maxHistory: number,
+  discardingSize: number,
+) {
+  if (!Array.isArray(commands)) {
+    commands = [commands];
+  }
+  for (const command of commands) {
+    history.commands.push(command);
+  }
+  if (history.commands.length > maxHistory) {
+    const d = Math.max(discardingSize, history.commands.length - maxHistory);
+    history.discarded += d;
+    history.commands.splice(0, d);
+  }
+}

--- a/src/common/advanced/prompt.ts
+++ b/src/common/advanced/prompt.ts
@@ -1,27 +1,4 @@
-import { Command } from "./command";
-
 export enum PromptTarget {
   CSA = "csa",
   USI = "usi",
-}
-
-export type PromptHistory = {
-  discarded: number;
-  commands: (Command & { id: number })[];
-};
-
-export function addCommand(history: PromptHistory, command: Command, maxHistory: number) {
-  history.commands.push({
-    id: Math.floor(Math.random() * Number.MAX_SAFE_INTEGER),
-    ...command,
-  });
-  if (
-    history.discarded !== 0
-      ? history.commands.length > maxHistory
-      : history.commands.length > maxHistory + 100
-  ) {
-    const discard = history.commands.length - maxHistory;
-    history.discarded += discard;
-    history.commands.splice(0, discard);
-  }
 }

--- a/src/renderer/ipc/api.ts
+++ b/src/renderer/ipc/api.ts
@@ -18,8 +18,8 @@ import { RecordFileHistory } from "@/common/file/history";
 import { InitialRecordFileRequest } from "@/common/file/record";
 import { VersionStatus } from "@/background/version/types";
 import { SessionStates } from "@/common/advanced/monitor";
-import { PromptHistory, PromptTarget } from "@/common/advanced/prompt";
-import { CommandType } from "@/common/advanced/command";
+import { PromptTarget } from "@/common/advanced/prompt";
+import { CommandHistory, CommandType } from "@/common/advanced/command";
 
 type AppInfo = {
   appVersion?: string;
@@ -216,7 +216,7 @@ export interface API {
   csaWin(sessionID: number): Promise<void>;
   csaStop(sessionID: number): Promise<void>;
   collectSessionStates(): Promise<SessionStates>;
-  setupPrompt(target: PromptTarget, sessionID: number): Promise<PromptHistory>;
+  setupPrompt(target: PromptTarget, sessionID: number): Promise<CommandHistory>;
   openPrompt(target: PromptTarget, sessionID: number, name: string): void;
   invokePromptCommand(
     target: PromptTarget,
@@ -345,7 +345,7 @@ const api: API = {
   async collectSessionStates(): Promise<SessionStates> {
     return JSON.parse(await bridge.collectSessionStates());
   },
-  async setupPrompt(target: PromptTarget, sessionID: number): Promise<PromptHistory> {
+  async setupPrompt(target: PromptTarget, sessionID: number): Promise<CommandHistory> {
     return JSON.parse(await bridge.setupPrompt(target, sessionID));
   },
   async getVersionStatus(): Promise<VersionStatus> {

--- a/src/renderer/view/prompt/CommandHistory.vue
+++ b/src/renderer/view/prompt/CommandHistory.vue
@@ -45,9 +45,7 @@
             highlight: searchText && entry.command.includes(searchText),
           }"
         >
-          <span v-if="showTimestamp" class="timestamp">{{
-            getDateTimeStringMs(new Date(entry.timeMs))
-          }}</span>
+          <span v-if="showTimestamp" class="timestamp">{{ entry.dateTime }}</span>
           <span v-if="entry.type === CommandType.SEND">&gt;</span>
           <span v-if="entry.type === CommandType.RECEIVE">&lt;</span>
           <span v-if="entry.type === CommandType.SYSTEM">#</span>
@@ -63,7 +61,6 @@ import { CommandType } from "@/common/advanced/command";
 import { useStore } from "@/renderer/prompt/store";
 import { onMounted, onUpdated, ref } from "vue";
 import ToggleButton from "@/renderer/view/primitive/ToggleButton.vue";
-import { getDateTimeStringMs } from "@/common/helpers/datetime";
 import { t } from "@/common/i18n";
 
 const store = useStore();

--- a/src/tests/common/advanced/command.spec.ts
+++ b/src/tests/common/advanced/command.spec.ts
@@ -1,0 +1,44 @@
+import { CommandHistory, CommandType, addCommand } from "@/common/advanced/command";
+
+describe("advanced/prompt", () => {
+  it("addCommand", () => {
+    const history = {
+      discarded: 0,
+      commands: [],
+    } as CommandHistory;
+    addCommand(
+      history,
+      [
+        { type: CommandType.SEND, command: "test01", dateTime: "t1", timeMs: 10 },
+        { type: CommandType.RECEIVE, command: "test02", dateTime: "t2", timeMs: 20 },
+        { type: CommandType.RECEIVE, command: "test03", dateTime: "t3", timeMs: 30 },
+        { type: CommandType.SEND, command: "test04", dateTime: "t4", timeMs: 40 },
+        { type: CommandType.SEND, command: "test05", dateTime: "t5", timeMs: 50 },
+        { type: CommandType.RECEIVE, command: "test06", dateTime: "t6", timeMs: 60 },
+      ],
+      10,
+      5,
+    );
+    expect(history.discarded).toBe(0);
+    expect(history.commands).toHaveLength(6);
+    expect(history.commands[0].command).toBe("test01");
+    expect(history.commands[5].command).toBe("test06");
+    addCommand(
+      history,
+      [
+        { type: CommandType.RECEIVE, command: "test07", dateTime: "t7", timeMs: 70 },
+        { type: CommandType.SEND, command: "test08", dateTime: "t8", timeMs: 80 },
+        { type: CommandType.SEND, command: "test09", dateTime: "t9", timeMs: 90 },
+        { type: CommandType.RECEIVE, command: "test10", dateTime: "t10", timeMs: 100 },
+        { type: CommandType.RECEIVE, command: "test11", dateTime: "t11", timeMs: 110 },
+        { type: CommandType.SEND, command: "test12", dateTime: "t12", timeMs: 120 },
+      ],
+      10,
+      5,
+    );
+    expect(history.discarded).toBe(5);
+    expect(history.commands).toHaveLength(7);
+    expect(history.commands[0].command).toBe("test06");
+    expect(history.commands[6].command).toBe("test12");
+  });
+});

--- a/src/tests/renderer/prompt/store.spec.ts
+++ b/src/tests/renderer/prompt/store.spec.ts
@@ -14,6 +14,10 @@ describe("prompt/store", () => {
       location: {
         toString: () => "file://foo/bar/?target=csa&session=123&name=test-server%3A4081",
       },
+      setTimeout: vi.fn().mockImplementation((fn) => {
+        fn();
+        return 0; // FIXME: これだとバッファリングのテストにならない。
+      }),
     });
   });
 
@@ -33,9 +37,9 @@ describe("prompt/store", () => {
     mockAPI.setupPrompt.mockResolvedValueOnce({
       discarded: 3,
       commands: [
-        { id: 111, type: CommandType.SEND, command: "foo", timeMs: 100 },
-        { id: 222, type: CommandType.RECEIVE, command: "bar", timeMs: 200 },
-        { id: 333, type: CommandType.SEND, command: "baz", timeMs: 300 },
+        { type: CommandType.SEND, command: "foo", dateTime: "t1", timeMs: 10 },
+        { type: CommandType.RECEIVE, command: "bar", dateTime: "t2", timeMs: 20 },
+        { type: CommandType.SEND, command: "baz", dateTime: "t3", timeMs: 30 },
       ],
     });
     const store = new Store();
@@ -46,18 +50,18 @@ describe("prompt/store", () => {
       random: vi.fn().mockReturnValue(0),
       floor: vi.fn().mockReturnValueOnce(444).mockReturnValueOnce(555).mockReturnValueOnce(666),
     });
-    store.onCommand({ type: CommandType.RECEIVE, command: "qux", timeMs: 400 });
-    store.onCommand({ type: CommandType.RECEIVE, command: "quux", timeMs: 500 });
-    store.onCommand({ type: CommandType.SEND, command: "corge", timeMs: 600 });
+    store.onCommand({ type: CommandType.RECEIVE, command: "qux", dateTime: "t4", timeMs: 40 });
+    store.onCommand({ type: CommandType.RECEIVE, command: "quux", dateTime: "t5", timeMs: 50 });
+    store.onCommand({ type: CommandType.SEND, command: "corge", dateTime: "t6", timeMs: 60 });
     expect(store.history).toStrictEqual({
       discarded: 3,
       commands: [
-        { id: 111, type: CommandType.SEND, command: "foo", timeMs: 100 },
-        { id: 222, type: CommandType.RECEIVE, command: "bar", timeMs: 200 },
-        { id: 333, type: CommandType.SEND, command: "baz", timeMs: 300 },
-        { id: 444, type: CommandType.RECEIVE, command: "qux", timeMs: 400 },
-        { id: 555, type: CommandType.RECEIVE, command: "quux", timeMs: 500 },
-        { id: 666, type: CommandType.SEND, command: "corge", timeMs: 600 },
+        { id: 0, type: CommandType.SEND, command: "foo", dateTime: "t1", timeMs: 10 },
+        { id: 1, type: CommandType.RECEIVE, command: "bar", dateTime: "t2", timeMs: 20 },
+        { id: 2, type: CommandType.SEND, command: "baz", dateTime: "t3", timeMs: 30 },
+        { id: 3, type: CommandType.RECEIVE, command: "qux", dateTime: "t4", timeMs: 40 },
+        { id: 4, type: CommandType.RECEIVE, command: "quux", dateTime: "t5", timeMs: 50 },
+        { id: 5, type: CommandType.SEND, command: "corge", dateTime: "t6", timeMs: 60 },
       ],
     });
   });


### PR DESCRIPTION
# 説明 / Description

大量のコマンドが流れるとプロンプトウィンドウのパフォーマンスが著しく悪化するため、一定時間内のコマンドをバッファリングしてまとめて描画する。
また、タイムスタンプを描画時にフォーマットするのではなく、表示用の文字列と Unix Time の両方を事前に持っておくようにする。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [ ] i18n
