### PR TITLE
評価値グラフの更新が重い問題を軽減

### DIFF
--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -23,7 +23,15 @@ import { reactive, UnwrapNestedRefs } from "vue";
 import { GameSetting } from "@/common/settings/game";
 import { ClockSoundTarget, Tab, TextDecodingRule } from "@/common/settings/app";
 import { beepShort, beepUnlimited, playPieceBeat, stopBeep } from "@/renderer/devices/audio";
-import { RecordManager, SearchInfoSenderType, SearchInfo as SearchInfoParam } from "./record";
+import {
+  RecordManager,
+  SearchInfoSenderType,
+  SearchInfo as SearchInfoParam,
+  ResetRecordHandler,
+  ChangePositionHandler,
+  UpdateCustomDataHandler,
+  UpdateFollowingMovesHandler,
+} from "./record";
 import { GameManager, GameResults } from "./game";
 import { generateRecordFileName, join } from "@/renderer/helpers/path";
 import { ResearchSetting } from "@/common/settings/research";
@@ -111,10 +119,32 @@ class Store {
   private mateSearchManager = new MateSearchManager();
   private _reactive: UnwrapNestedRefs<Store>;
   private garbledNotified = false;
+  private onResetRecordHandlers: ResetRecordHandler[] = [];
+  private onChangePositionHandlers: ChangePositionHandler[] = [];
+  private onUpdateCustomDataHandlers: UpdateCustomDataHandler[] = [];
+  private onUpdateFollowingMovesHandlers: (() => void)[] = [];
 
   constructor() {
+    this.recordManager.on("resetRecord", () => {
+      for (const handler of this.onResetRecordHandlers) {
+        handler();
+      }
+    });
     this.recordManager.on("changePosition", () => {
-      this.onUpdatePosition();
+      this.updateResearchPosition();
+      for (const handler of this.onChangePositionHandlers) {
+        handler();
+      }
+    });
+    this.recordManager.on("updateCustomData", () => {
+      for (const handler of this.onUpdateCustomDataHandlers) {
+        handler();
+      }
+    });
+    this.recordManager.on("updateFollowingMoves", () => {
+      for (const handler of this.onUpdateFollowingMovesHandlers) {
+        handler();
+      }
     });
     const refs = reactive(this);
     const appSetting = useAppSetting();
@@ -150,6 +180,52 @@ class Store {
       .on("noMate", this.onNoMate.bind(refs))
       .on("error", this.onCheckmateError.bind(refs));
     this._reactive = refs;
+  }
+
+  addEventListener(event: "resetRecord", handler: ResetRecordHandler): void;
+  addEventListener(event: "changePosition", handler: ChangePositionHandler): void;
+  addEventListener(event: "updateCustomData", handler: UpdateCustomDataHandler): void;
+  addEventListener(event: "updateFollowingMoves", handler: UpdateFollowingMovesHandler): void;
+  addEventListener(event: string, handler: unknown): void {
+    switch (event) {
+      case "resetRecord":
+        this.onResetRecordHandlers.push(handler as ResetRecordHandler);
+        break;
+      case "changePosition":
+        this.onChangePositionHandlers.push(handler as ChangePositionHandler);
+        break;
+      case "updateCustomData":
+        this.onUpdateCustomDataHandlers.push(handler as UpdateCustomDataHandler);
+        break;
+      case "updateFollowingMoves":
+        this.onUpdateFollowingMovesHandlers.push(handler as UpdateFollowingMovesHandler);
+        break;
+    }
+  }
+
+  removeEventListener(event: "resetRecord", handler: ResetRecordHandler): void;
+  removeEventListener(event: "changePosition", handler: ChangePositionHandler): void;
+  removeEventListener(event: "updateCustomData", handler: UpdateCustomDataHandler): void;
+  removeEventListener(event: "updateFollowingMoves", handler: UpdateFollowingMovesHandler): void;
+  removeEventListener(event: string, handler: unknown): void {
+    switch (event) {
+      case "resetRecord":
+        this.onResetRecordHandlers = this.onResetRecordHandlers.filter((h) => h !== handler);
+        break;
+      case "changePosition":
+        this.onChangePositionHandlers = this.onChangePositionHandlers.filter((h) => h !== handler);
+        break;
+      case "updateCustomData":
+        this.onUpdateCustomDataHandlers = this.onUpdateCustomDataHandlers.filter(
+          (h) => h !== handler,
+        );
+        break;
+      case "updateFollowingMoves":
+        this.onUpdateFollowingMovesHandlers = this.onUpdateFollowingMovesHandlers.filter(
+          (h) => h !== handler,
+        );
+        break;
+    }
   }
 
   get reactive(): UnwrapNestedRefs<Store> {
@@ -688,7 +764,7 @@ class Store {
       .then(() => {
         this._appState = AppState.RESEARCH;
         this.usiMonitor.clear();
-        this.onUpdatePosition();
+        this.updateResearchPosition();
         const appSetting = useAppSetting();
         if (
           appSetting.tab !== Tab.SEARCH &&
@@ -826,7 +902,7 @@ class Store {
     this._appState = AppState.NORMAL;
   }
 
-  onUpdatePosition(): void {
+  updateResearchPosition(): void {
     if (this.researchManager) {
       this.researchManager.updatePosition(this.recordManager.record);
     }


### PR DESCRIPTION
# 説明 / Description

#748 

EvaluationChart.vue の更新負荷の問題を軽減します。

1. RecordManager から以下の 3 つのイベントを新たに取得できるようにして棋譜に対して watch 関数による監視をしないよう修正します。
    - resetRecord - 棋譜の初期化
    - updateCustomData - カスタムデータ（評価値）の更新
    - updateFollowingMoves - 後続の指し手の更新（読み筋を棋譜に挿入したとき）
2. AppSettings 全体を watch 関数で監視するのをやめて、 Chart に必要なフィールドの変更だけをハンドリングします。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
