### PR TITLE
fix: move-time width

### DIFF
--- a/src/renderer/view/primitive/RecordView.vue
+++ b/src/renderer/view/primitive/RecordView.vue
@@ -310,7 +310,7 @@ onUpdated(() => {
   text-overflow: clip;
 }
 .move-time {
-  min-width: 90px;
+  min-width: fit-content;
   height: 100%;
   padding-right: 5px;
   text-align: left;


### PR DESCRIPTION

# 説明 / Description

Closes #767 

消費時間にコメントが重なっていた問題を修正しました。

動作確認は Linux (Ubuntu22.04 WSL2) 環境でのみ行っています。

![image](https://github.com/sunfish-shogi/electron-shogi/assets/24248467/539e93f1-5d2e-4e62-9f9f-fb29fc65e771)

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [x] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
