### PR TITLE
Select default return code automatically

### DIFF
--- a/src/command/usi-csa-bridge/index.ts
+++ b/src/command/usi-csa-bridge/index.ts
@@ -41,7 +41,7 @@ const recordFileFormat = argParser.valueOrNull(
 const returnCodeName = argParser.value(
   "return-code",
   "Return code which one of LF or CRLF. It is used for record file.",
-  "CRLF",
+  process.platform === "win32" ? "CRLF" : "LF",
   ["LF", "CRLF"],
 );
 const repeat = argParser.numberOrNull("repeat", "Overwrite repeat setting.", { min: 1 });


### PR DESCRIPTION
# 説明 / Description

usi-csa-bridge の `--return-code` オプションのデフォルト値を OS に応じて自動的に選択します。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
