### PR TITLE
test: remove catch in tests

### DIFF
--- a/src/tests/background/file/history.spec.ts
+++ b/src/tests/background/file/history.spec.ts
@@ -55,22 +55,13 @@ it("history", async () => {
   history = await getHistory();
   expect(history.entries).toHaveLength(20);
   expect(history.entries[0].backupFileName).toMatch(backupFileName2);
-  try {
-    await loadBackup(backupFileName1);
-    throw "should not reach here";
-  } catch {
-    // shoud reach here
-  }
+  await expect(() => loadBackup(backupFileName1)).rejects.toThrow();
+
   expect(await loadBackup(backupFileName2)).toBe("test-kif-data2");
 
   await clearHistory();
 
   history = await getHistory();
   expect(history.entries).toHaveLength(0);
-  try {
-    await loadBackup(backupFileName2);
-    throw "should not reach here";
-  } catch {
-    // shoud reach here
-  }
+  await expect(() => loadBackup(backupFileName2)).rejects.toThrow();
 });

--- a/src/tests/command/common/arguments.spec.ts
+++ b/src/tests/command/common/arguments.spec.ts
@@ -59,11 +59,7 @@ describe("command/common/arguments", () => {
     process.argv = ["node", "test-command", "--num1", "foo"];
     const parser = new ArgumentsParser("test-command", "<arg1> <arg2>");
     parser.number("num1", "number 1", 1);
-    try {
-      parser.parse();
-    } catch {
-      // ignore
-    }
+    expect(() => parser.parse()).toThrow();
     expect(exit).toHaveBeenCalledWith(1);
   });
 
@@ -79,11 +75,7 @@ describe("command/common/arguments", () => {
     process.argv = ["node", "test-command", "--opt1", "baz"];
     const parser = new ArgumentsParser("test-command", "<arg1> <arg2>");
     parser.value("opt1", "option 1", "default1", ["foo", "bar"]);
-    try {
-      parser.parse();
-    } catch {
-      // ignore
-    }
+    expect(() => parser.parse()).toThrow();
     expect(exit).toHaveBeenCalledWith(1);
   });
 
@@ -99,11 +91,7 @@ describe("command/common/arguments", () => {
     process.argv = ["node", "test-command", "--num1", "99"];
     const parser = new ArgumentsParser("test-command", "<arg1> <arg2>");
     parser.number("num1", "number 1", 1, { min: 100, max: 200 });
-    try {
-      parser.parse();
-    } catch {
-      // ignore
-    }
+    expect(() => parser.parse()).toThrow();
     expect(exit).toHaveBeenCalledWith(1);
   });
 
@@ -119,11 +107,7 @@ describe("command/common/arguments", () => {
     process.argv = ["node", "test-command", "--num1", "201"];
     const parser = new ArgumentsParser("test-command", "<arg1> <arg2>");
     parser.number("num1", "number 1", 1, { min: 100, max: 200 });
-    try {
-      parser.parse();
-    } catch {
-      // ignore
-    }
+    expect(() => parser.parse()).toThrow();
     expect(exit).toHaveBeenCalledWith(1);
   });
 
@@ -131,11 +115,7 @@ describe("command/common/arguments", () => {
     const exit = vi.spyOn(process, "exit").mockImplementation(neverFunc);
     process.argv = ["node", "test-command", "--opt", "foo"];
     const parser = new ArgumentsParser("test-command", "<arg1> <arg2>");
-    try {
-      parser.parse();
-    } catch {
-      // ignore
-    }
+    expect(() => parser.parse()).toThrow();
     expect(exit).toHaveBeenCalledWith(1);
   });
 

--- a/src/tests/renderer/store/setting.spec.ts
+++ b/src/tests/renderer/store/setting.spec.ts
@@ -40,14 +40,12 @@ describe("store/index", () => {
 
   it("updateAppSetting/error", async () => {
     const store = createAppSetting();
-    try {
-      await store.updateAppSetting({
+    await expect(() =>
+      store.updateAppSetting({
         pieceVolume: -1,
-      });
-      throw new Error("updateAppSetting must be rejected");
-    } catch {
-      expect(store.pieceVolume).toBe(30);
-    }
+      }),
+    ).rejects.toThrow();
+    expect(store.pieceVolume).toBe(30);
   });
 
   it("flipBoard", () => {


### PR DESCRIPTION
# 説明 / Description

- テスト内の `try...catch` を `expect().toThrow()` に変更

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [x] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
