### PR TITLE
Use v121_floodgate as default setting

### DIFF
--- a/src/common/settings/csa.ts
+++ b/src/common/settings/csa.ts
@@ -48,7 +48,7 @@ export type CSAGameSetting = {
 
 export function defaultCSAServerSetting(): CSAServerSetting {
   return {
-    protocolVersion: CSAProtocolVersion.V121,
+    protocolVersion: CSAProtocolVersion.V121_FLOODGATE,
     host: "localhost",
     port: 4081,
     id: "",
@@ -229,7 +229,7 @@ export type SecureCSAServerSetting = {
 
 export function emptySecureCSAServerSetting(): SecureCSAServerSetting {
   return {
-    protocolVersion: CSAProtocolVersion.V121,
+    protocolVersion: CSAProtocolVersion.V121_FLOODGATE,
     host: "",
     port: 0,
     id: "",


### PR DESCRIPTION
# 説明 / Description

WCSC でも前回大会から評価値や読み筋を送ることができるようになったので、 CSA プロトコルのバージョンは V1.2.1 の Floodgate 拡張版をデフォルトにする。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the protocol version in server settings to enhance security and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->