### PR TITLE
Add unequal time config support

### DIFF
--- a/src/common/game/csa.ts
+++ b/src/common/game/csa.ts
@@ -1,17 +1,37 @@
 import { Color } from "electron-shogi-core";
 
-export type CSAGameSummary = {
-  id: string;
-  blackPlayerName?: string;
-  whitePlayerName?: string;
-  myColor: Color.BLACK | Color.WHITE;
-  toMove: Color.BLACK | Color.WHITE;
-  position: string;
+export type CSAGameTimeConfig = {
   timeUnitMs: number;
   totalTime: number;
   byoyomi: number;
   delay: number;
   increment: number;
+};
+
+export type CSAGamePlayerConfig = {
+  playerName?: string;
+  time: CSAGameTimeConfig;
+};
+
+function emptyCSAGameTimeConfig(): CSAGameTimeConfig {
+  return {
+    timeUnitMs: 1e3,
+    totalTime: 0,
+    byoyomi: 0,
+    delay: 0,
+    increment: 0,
+  };
+}
+
+export type CSAGameSummary = {
+  id: string;
+  players: {
+    black: CSAGamePlayerConfig;
+    white: CSAGamePlayerConfig;
+  };
+  myColor: Color.BLACK | Color.WHITE;
+  toMove: Color.BLACK | Color.WHITE;
+  position: string;
 };
 
 export function emptyCSAGameSummary(): CSAGameSummary {
@@ -20,11 +40,14 @@ export function emptyCSAGameSummary(): CSAGameSummary {
     myColor: Color.BLACK,
     toMove: Color.BLACK,
     position: "",
-    timeUnitMs: 1e3,
-    totalTime: 0,
-    byoyomi: 0,
-    delay: 0,
-    increment: 0,
+    players: {
+      black: {
+        time: emptyCSAGameTimeConfig(),
+      },
+      white: {
+        time: emptyCSAGameTimeConfig(),
+      },
+    },
   };
 }
 

--- a/src/tests/background/csa/client.spec.ts
+++ b/src/tests/background/csa/client.spec.ts
@@ -193,6 +193,71 @@ const mockGameSummaryInvalidPosition = [
   "END Game_Summary",
 ];
 
+const mockGameSummaryWithUnequalTime = [
+  "BEGIN Game_Summary",
+  "Protocol_Version:1.2",
+  "Protocol_Mode:Server",
+  "Format:Shogi 1.0",
+  "Declaration:Jishogi 1.1",
+  "Game_ID:20150505-CSA25-3-5-7",
+  "Name+:TANUKI",
+  "Name-:KITSUNE",
+  "Your_Turn:-",
+  "Rematch_On_Draw:NO",
+  "To_Move:+",
+  "Max_Moves:256",
+  "BEGIN Time+",
+  "Time_Unit:1sec",
+  "Total_Time:300",
+  "Byoyomi:10",
+  "Least_Time_Per_Move:1",
+  "END Time+",
+  "BEGIN Time-",
+  "Time_Unit:1sec",
+  "Total_Time:600",
+  "Byoyomi:30",
+  "Least_Time_Per_Move:1",
+  "END Time-",
+  "BEGIN Position",
+  "局面1行目",
+  "局面2行目",
+  "END Position",
+  "END Game_Summary",
+];
+
+const mockGameSummaryWithUnequalTimeAndIncremnt = [
+  "BEGIN Game_Summary",
+  "Protocol_Version:1.2",
+  "Protocol_Mode:Server",
+  "Format:Shogi 1.0",
+  "Declaration:Jishogi 1.1",
+  "Game_ID:20150505-CSA25-3-5-7",
+  "Name+:TANUKI",
+  "Name-:KITSUNE",
+  "Your_Turn:-",
+  "Rematch_On_Draw:NO",
+  "To_Move:+",
+  "Max_Moves:256",
+  "BEGIN Time+",
+  "Time_Unit:1sec",
+  "Total_Time:300",
+  "Increment:5",
+  "Delay:1",
+  "Least_Time_Per_Move:1",
+  "END Time+",
+  "BEGIN Time-",
+  "Time_Unit:1sec",
+  "Total_Time:600",
+  "Increment:10",
+  "Least_Time_Per_Move:1",
+  "END Time-",
+  "BEGIN Position",
+  "局面1行目",
+  "局面2行目",
+  "END Position",
+  "END Game_Summary",
+];
+
 function bindHandlers(client: Client) {
   const handlers = {
     mockOnGameSummary: vi.fn(),
@@ -239,16 +304,19 @@ describe("background/csa/client", () => {
     expect(clientHandlers.mockOnGameSummary).toBeCalledTimes(1);
     expect(clientHandlers.mockOnGameSummary.mock.calls[0][0]).toStrictEqual({
       id: "20150505-CSA25-3-5-7",
-      blackPlayerName: "TANUKI",
-      whitePlayerName: "KITSUNE",
+      players: {
+        black: {
+          playerName: "TANUKI",
+          time: { timeUnitMs: 1000, totalTime: 600, byoyomi: 10, delay: 0, increment: 0 },
+        },
+        white: {
+          playerName: "KITSUNE",
+          time: { timeUnitMs: 1000, totalTime: 600, byoyomi: 10, delay: 0, increment: 0 },
+        },
+      },
       myColor: Color.WHITE,
       toMove: Color.BLACK,
       position: "局面1行目\n局面2行目\n",
-      timeUnitMs: 1000,
-      totalTime: 600,
-      byoyomi: 10,
-      delay: 0,
-      increment: 0,
     });
     client.agree("20150505-CSA25-3-5-7");
     expect(mockSocket.prototype.write).toBeCalledTimes(2);
@@ -354,16 +422,19 @@ describe("background/csa/client", () => {
     expect(clientHandlers.mockOnGameSummary).toBeCalledTimes(1);
     expect(clientHandlers.mockOnGameSummary.mock.calls[0][0]).toStrictEqual({
       id: "20150505-CSA25-3-5-7",
-      blackPlayerName: "TANUKI",
-      whitePlayerName: "KITSUNE",
+      players: {
+        black: {
+          playerName: "TANUKI",
+          time: { timeUnitMs: 1000, totalTime: 600, byoyomi: 10, delay: 0, increment: 0 },
+        },
+        white: {
+          playerName: "KITSUNE",
+          time: { timeUnitMs: 1000, totalTime: 600, byoyomi: 10, delay: 0, increment: 0 },
+        },
+      },
       myColor: Color.WHITE,
       toMove: Color.BLACK,
       position: "局面1行目\n局面2行目\n",
-      timeUnitMs: 1000,
-      totalTime: 600,
-      byoyomi: 10,
-      delay: 0,
-      increment: 0,
     });
     client.agree("20150505-CSA25-3-5-7");
     expect(mockSocket.prototype.write).toBeCalledTimes(2);
@@ -566,16 +637,19 @@ describe("background/csa/client", () => {
     expect(clientHandlers.mockOnGameSummary).toBeCalledTimes(1);
     expect(clientHandlers.mockOnGameSummary.mock.calls[0][0]).toStrictEqual({
       id: "20150505-CSA25-3-5-7",
-      blackPlayerName: "TANUKI",
-      whitePlayerName: "KITSUNE",
+      players: {
+        black: {
+          playerName: "TANUKI",
+          time: { timeUnitMs: 1000, totalTime: 900, byoyomi: 0, delay: 0, increment: 5 },
+        },
+        white: {
+          playerName: "KITSUNE",
+          time: { timeUnitMs: 1000, totalTime: 900, byoyomi: 0, delay: 0, increment: 5 },
+        },
+      },
       myColor: Color.BLACK,
       toMove: Color.BLACK,
       position: "局面1行目\n局面2行目\n",
-      timeUnitMs: 1000,
-      totalTime: 900,
-      byoyomi: 0,
-      delay: 0,
-      increment: 5,
     });
     client.agree("20150505-CSA25-3-5-7");
     socketHandlers.onRead("START:20150505-CSA25-3-5-7");
@@ -616,8 +690,16 @@ describe("background/csa/client", () => {
     expect(clientHandlers.mockOnGameSummary).toBeCalledTimes(1);
     expect(clientHandlers.mockOnGameSummary.mock.calls[0][0]).toStrictEqual({
       id: "20150505-CSA25-3-5-7",
-      blackPlayerName: "TANUKI",
-      whitePlayerName: "KITSUNE",
+      players: {
+        black: {
+          playerName: "TANUKI",
+          time: { timeUnitMs: 1000, totalTime: 900, byoyomi: 0, delay: 0, increment: 5 },
+        },
+        white: {
+          playerName: "KITSUNE",
+          time: { timeUnitMs: 1000, totalTime: 900, byoyomi: 0, delay: 0, increment: 5 },
+        },
+      },
       myColor: Color.BLACK,
       toMove: Color.BLACK,
       position:
@@ -637,11 +719,6 @@ describe("background/csa/client", () => {
         "-3334FU,T6\n" +
         "+7776FU,T5\n" +
         "-8384FU,T7\n",
-      timeUnitMs: 1000,
-      totalTime: 900,
-      byoyomi: 0,
-      delay: 0,
-      increment: 5,
     });
     client.agree("20150505-CSA25-3-5-7");
     socketHandlers.onRead("START:20150505-CSA25-3-5-7");
@@ -682,8 +759,28 @@ describe("background/csa/client", () => {
     expect(clientHandlers.mockOnGameSummary).toBeCalledTimes(1);
     expect(clientHandlers.mockOnGameSummary.mock.calls[0][0]).toStrictEqual({
       id: "20150505-CSA25-3-5-7",
-      blackPlayerName: "TANUKI",
-      whitePlayerName: "KITSUNE",
+      players: {
+        black: {
+          playerName: "TANUKI",
+          time: {
+            timeUnitMs: 1,
+            totalTime: 900 * 1e3,
+            byoyomi: 0,
+            delay: 0,
+            increment: 5 * 1e3,
+          },
+        },
+        white: {
+          playerName: "KITSUNE",
+          time: {
+            timeUnitMs: 1,
+            totalTime: 900 * 1e3,
+            byoyomi: 0,
+            delay: 0,
+            increment: 5 * 1e3,
+          },
+        },
+      },
       myColor: Color.BLACK,
       toMove: Color.BLACK,
       position:
@@ -703,11 +800,6 @@ describe("background/csa/client", () => {
         "-3334FU,T6\n" +
         "+7776FU,T5\n" +
         "-8384FU,T7\n",
-      timeUnitMs: 1,
-      totalTime: 900 * 1e3,
-      byoyomi: 0,
-      delay: 0,
-      increment: 5 * 1e3,
     });
     client.agree("20150505-CSA25-3-5-7");
     socketHandlers.onRead("START:20150505-CSA25-3-5-7");
@@ -748,16 +840,19 @@ describe("background/csa/client", () => {
     expect(clientHandlers.mockOnGameSummary).toBeCalledTimes(1);
     expect(clientHandlers.mockOnGameSummary.mock.calls[0][0]).toStrictEqual({
       id: "20150505-CSA25-3-5-7",
-      blackPlayerName: "TANUKI",
-      whitePlayerName: "KITSUNE",
+      players: {
+        black: {
+          playerName: "TANUKI",
+          time: { timeUnitMs: 60 * 1e3, totalTime: 15, byoyomi: 1, delay: 0, increment: 0 },
+        },
+        white: {
+          playerName: "KITSUNE",
+          time: { timeUnitMs: 60 * 1e3, totalTime: 15, byoyomi: 1, delay: 0, increment: 0 },
+        },
+      },
       myColor: Color.BLACK,
       toMove: Color.BLACK,
       position: "局面1行目\n局面2行目\n",
-      timeUnitMs: 60 * 1e3,
-      totalTime: 15,
-      byoyomi: 1,
-      delay: 0,
-      increment: 0,
     });
     client.agree("20150505-CSA25-3-5-7");
     socketHandlers.onRead("START:20150505-CSA25-3-5-7");
@@ -807,5 +902,63 @@ describe("background/csa/client", () => {
     expect(clientHandlers.mockOnError).toBeCalledTimes(1);
     expect(mockSocket.prototype.write).toBeCalledTimes(2);
     expect(mockSocket.prototype.write.mock.calls[1][0]).toBe("LOGOUT");
+  });
+
+  it("unequal_time_settings", async () => {
+    const client = new Client(123, csaServerSetting, log4js.getLogger());
+    const clientHandlers = bindHandlers(client);
+    client.login();
+    const socketHandlers = mockSocket.mock.calls[0][2];
+    socketHandlers.onConnect();
+    socketHandlers.onRead("LOGIN:TestPlayer OK");
+    for (const line of mockGameSummaryWithUnequalTime) {
+      socketHandlers.onRead(line);
+    }
+    expect(clientHandlers.mockOnGameSummary).toBeCalledTimes(1);
+    expect(clientHandlers.mockOnGameSummary.mock.calls[0][0]).toStrictEqual({
+      id: "20150505-CSA25-3-5-7",
+      players: {
+        black: {
+          playerName: "TANUKI",
+          time: { timeUnitMs: 1000, totalTime: 300, byoyomi: 10, delay: 0, increment: 0 },
+        },
+        white: {
+          playerName: "KITSUNE",
+          time: { timeUnitMs: 1000, totalTime: 600, byoyomi: 30, delay: 0, increment: 0 },
+        },
+      },
+      myColor: Color.WHITE,
+      toMove: Color.BLACK,
+      position: "局面1行目\n局面2行目\n",
+    });
+  });
+
+  it("unequal_time_settings_with_increment", async () => {
+    const client = new Client(123, csaServerSetting, log4js.getLogger());
+    const clientHandlers = bindHandlers(client);
+    client.login();
+    const socketHandlers = mockSocket.mock.calls[0][2];
+    socketHandlers.onConnect();
+    socketHandlers.onRead("LOGIN:TestPlayer OK");
+    for (const line of mockGameSummaryWithUnequalTimeAndIncremnt) {
+      socketHandlers.onRead(line);
+    }
+    expect(clientHandlers.mockOnGameSummary).toBeCalledTimes(1);
+    expect(clientHandlers.mockOnGameSummary.mock.calls[0][0]).toStrictEqual({
+      id: "20150505-CSA25-3-5-7",
+      players: {
+        black: {
+          playerName: "TANUKI",
+          time: { timeUnitMs: 1000, totalTime: 300, byoyomi: 0, delay: 1, increment: 5 },
+        },
+        white: {
+          playerName: "KITSUNE",
+          time: { timeUnitMs: 1000, totalTime: 600, byoyomi: 0, delay: 0, increment: 10 },
+        },
+      },
+      myColor: Color.WHITE,
+      toMove: Color.BLACK,
+      position: "局面1行目\n局面2行目\n",
+    });
   });
 });

--- a/src/tests/mock/csa.ts
+++ b/src/tests/mock/csa.ts
@@ -121,32 +121,67 @@ P-
 
 export const csaGameSummary: CSAGameSummary = {
   id: "test-game",
-  blackPlayerName: "me",
-  whitePlayerName: "enemy",
+  players: {
+    black: {
+      playerName: "me",
+      time: { timeUnitMs: 1000, totalTime: 600, byoyomi: 30, delay: 0, increment: 0 },
+    },
+    white: {
+      playerName: "enemy",
+      time: { timeUnitMs: 1000, totalTime: 600, byoyomi: 30, delay: 0, increment: 0 },
+    },
+  },
   myColor: Color.BLACK,
   toMove: Color.BLACK,
   position: initialPosition,
-  timeUnitMs: 1000,
-  totalTime: 600,
-  byoyomi: 30,
-  delay: 0,
-  increment: 0,
+};
+
+export const csaGameSummaryWithUnequalTimeConfig: CSAGameSummary = {
+  id: "test-game",
+  players: {
+    black: {
+      playerName: "me",
+      time: { timeUnitMs: 1000, totalTime: 300, byoyomi: 0, delay: 0, increment: 5 },
+    },
+    white: {
+      playerName: "enemy",
+      time: { timeUnitMs: 1000, totalTime: 600, byoyomi: 0, delay: 0, increment: 10 },
+    },
+  },
+  myColor: Color.BLACK,
+  toMove: Color.BLACK,
+  position: initialPosition,
 };
 
 const invalidPosition = `+2726FU,T12`;
 
 export const csaGameSummaryInvalidPosition: CSAGameSummary = {
   id: "test-game",
-  blackPlayerName: "me",
-  whitePlayerName: "enemy",
+  players: {
+    black: {
+      playerName: "me",
+      time: {
+        timeUnitMs: 1000,
+        totalTime: 600,
+        byoyomi: 30,
+        delay: 0,
+        increment: 0,
+      },
+    },
+    white: {
+      playerName: "enemy",
+      time: {
+        timeUnitMs: 1000,
+        totalTime: 600,
+        byoyomi: 30,
+        delay: 0,
+        increment: 0,
+      },
+    },
+  },
   myColor: Color.BLACK,
   toMove: Color.BLACK,
   position: invalidPosition,
-  timeUnitMs: 1000,
-  totalTime: 600,
-  byoyomi: 30,
-  delay: 0,
-  increment: 0,
 };
 
 export const csaGameSettingForCLI: CSAGameSettingForCLI = {

--- a/src/tests/mock/player.ts
+++ b/src/tests/mock/player.ts
@@ -45,7 +45,7 @@ export function createMockPlayer(moves: { [usi: string]: MoveWithOption }) {
       );
       return Promise.resolve();
     }),
-    startPonder: vi.fn(() => Promise.resolve()),
+    startPonder: vi.fn<[ImmutablePosition, string, TimeStates]>(() => Promise.resolve()),
     startMateSearch: vi.fn(() => Promise.resolve()),
     stop: vi.fn(() => Promise.resolve()),
     gameover: vi.fn(() => Promise.resolve()),


### PR DESCRIPTION
# 説明 / Description

#778 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced player-specific time configurations for black and white players, enhancing game time management and accuracy.
- **Bug Fixes**
	- Adjusted game summary and time calculations to accurately reflect player-specific times.
- **Refactor**
	- Refactored time management code to utilize player-specific time configurations, improving clarity and accuracy.
- **Tests**
	- Updated tests to cover new scenarios with unequal time configurations and player-specific time management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->