### PR TITLE
ボタンの文言を修正 (v1.13)

### DIFF
--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -327,6 +327,7 @@ export const en: Texts = {
   userFile: "User File",
   automaticBackup: "Automatic Backup",
   restore: "Restore",
+  ok: "OK",
   cancel: "Cancel",
   back: "Back",
   name: "Name",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -327,6 +327,7 @@ export const ja: Texts = {
   userFile: "ユーザーのファイル",
   automaticBackup: "自動バックアップ",
   restore: "復元",
+  ok: "OK",
   cancel: "キャンセル",
   back: "戻る",
   name: "名前",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -324,6 +324,7 @@ export const zh_tw: Texts = {
   userFile: "使用者檔案",
   automaticBackup: "自動備份",
   restore: "復原",
+  ok: "OK",
   cancel: "取消",
   back: "返回",
   name: "名稱",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -322,6 +322,7 @@ export type Texts = {
   userFile: string;
   automaticBackup: string;
   restore: string;
+  ok: string;
   cancel: string;
   back: string;
   name: string;

--- a/src/renderer/view/dialog/ConnectToCSAServerDialog.vue
+++ b/src/renderer/view/dialog/ConnectToCSAServerDialog.vue
@@ -53,7 +53,7 @@
       </div>
       <div class="main-buttons">
         <button data-hotkey="Enter" autofocus @click="onStart()">
-          {{ t.startGame }}
+          {{ t.ok }}
         </button>
         <button data-hotkey="Escape" @click="onCancel()">
           {{ t.cancel }}


### PR DESCRIPTION
# 説明 / Description

CSA の管理ログインのボタンが「対局開始」だったのを修正する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the ElectronShogi app to version 1.13.5.
	- Enhanced styling for dialog and menu components in the game interface.
- **Documentation**
	- Updated links and version information across multiple documentation pages.
- **Bug Fixes**
	- Adjusted import paths for modules in web assets.
- **Refactor**
	- Improved code structure and simplified functions related to game time management and internationalization.
- **Style**
	- Introduced new styles for dialog boxes.
- **Tests**
	- Enhanced testing configurations for game engine functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->