### PR TITLE
ボタンの文言を修正

### DIFF
--- a/src/renderer/view/dialog/ConnectToCSAServerDialog.vue
+++ b/src/renderer/view/dialog/ConnectToCSAServerDialog.vue
@@ -53,7 +53,7 @@
       </div>
       <div class="main-buttons">
         <button data-hotkey="Enter" autofocus @click="onStart()">
-          {{ t.startGame }}
+          {{ t.ok }}
         </button>
         <button data-hotkey="Escape" @click="onCancel()">
           {{ t.cancel }}


### PR DESCRIPTION
# 説明 / Description

CSA の管理ログインのボタンが「対局開始」だったのを修正する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
