### PR TITLE
Ctrl+N (Cmd+N) を新規棋譜に割り当て

### DIFF
--- a/src/background/window/menu.ts
+++ b/src/background/window/menu.ts
@@ -70,7 +70,7 @@ function createMenuTemplate(window: BrowserWindow) {
     {
       label: t.file,
       submenu: [
-        menuItem(t.newRecord, MenuEvent.NEW_RECORD, [AppState.NORMAL]),
+        menuItem(t.newRecord, MenuEvent.NEW_RECORD, [AppState.NORMAL], "CmdOrCtrl+N"),
         menuItem(t.openRecord, MenuEvent.OPEN_RECORD, [AppState.NORMAL], "CmdOrCtrl+O"),
         menuItem(t.saveRecord, MenuEvent.SAVE_RECORD, [AppState.NORMAL], "CmdOrCtrl+S"),
         menuItem(t.saveRecordAs, MenuEvent.SAVE_RECORD_AS, [AppState.NORMAL], "CmdOrCtrl+Shift+S"),


### PR DESCRIPTION
# 説明 / Description

Ctrl+N (Cmd+N) で新規棋譜の編集を開始できるようにする。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced keyboard shortcuts: Users can now create new records using "CmdOrCtrl+N" shortcut.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->