### PR TITLE
Fix the evaluation chart ignoring mates if there is a score given

### DIFF
--- a/src/renderer/view/tab/EvaluationChart.vue
+++ b/src/renderer/view/tab/EvaluationChart.vue
@@ -93,14 +93,11 @@ function getScore(
   type: EvaluationChartType,
   coefficientInSigmoid: number,
 ): number | undefined {
-  const score =
-    searchInfo.score !== undefined
-      ? searchInfo.score
-      : searchInfo.mate !== undefined
-        ? searchInfo.mate > 0
-          ? MATE_SCORE
-          : -MATE_SCORE
-        : undefined;
+  let score = searchInfo.score;
+  // mateがある場合はMATE_SCOREを代わりに使用する。
+  if (searchInfo.mate !== undefined) {
+    score = searchInfo.mate > 0 ? MATE_SCORE : -MATE_SCORE;
+  }
   if (score === undefined) {
     return;
   }


### PR DESCRIPTION
# 説明 / Description
The logic for giving mates a higher priority than the score was backwards.

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [x] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the score calculation in the evaluation chart to more explicitly handle scenarios involving 'mate' conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->