### PR TITLE
Fix unrecommended setting in `tsconfig.json`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,11 +10,10 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,
-    "baseUrl": ".",
     "outDir": "dist/src",
     "types": ["vitest/globals"],
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     },
     "lib": ["esnext", "dom", "dom.iterable", "scripthost"]
   },


### PR DESCRIPTION
# 説明 / Description

`tsconfig.json` の設定について、[TypeScript のドキュメント](https://www.typescriptlang.org/tsconfig/#baseUrl)によると、

> This feature was designed for use in conjunction with AMD module loaders in the browser, and is not recommended in any other context. As of TypeScript 4.1, baseUrl is no longer required to be set when using [paths](https://www.typescriptlang.org/tsconfig/#paths).

と書いてあって、`baseUrl` を設定するのは推奨されないようなので、`baseUrl` の項目を消して、それに応じて `paths` の項目を修正しました。

# チェックリスト / Checklist

- MUST
  - [ ] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [x] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n

# テストに関して / About Test

テストは通っているのか通っていないのか良く分からないです。

```
$ npm test

> electron-shogi@1.14.1 test
> vitest run


 RUN  v1.6.0 /Users/paalon/git/electron-shogi

(node:13443) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
(node:13443) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
(node:13443) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/renderer/store/index.spec.ts (35) 377ms
(node:13443) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/renderer/store/index.spec.ts (35) 377ms
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/renderer/store/index.spec.ts (35) 377ms
 ✓ src/tests/background/usi/engine.spec.ts (8)
 ✓ src/tests/renderer/store/game.spec.ts (12)
 ✓ src/tests/renderer/store/record.spec.ts (16)
 ✓ src/tests/common/settings/usi.spec.ts (12)
 ✓ src/tests/background/file/conversion.spec.ts (2) 560ms
 ✓ src/tests/common/settings/csa.spec.ts (12)
 ✓ src/tests/background/version/version.spec.ts (10)
 ✓ src/tests/renderer/players/usi.spec.ts (3)
 ✓ src/tests/renderer/store/clock.spec.ts (3)
 · src/tests/background/usi/index.spec.ts (4)
[2024-05-31T17:42:42.538] [INFO] usi - sid=1: > usi
[2024-05-31T17:42:42.540] [INFO] usi - sid=1: < id name DummyEngine
[2024-05-31T17:42:42.540] [INFO] usi - sid=1: < id author Ryosuke Kubo
[2024-05-31T17:42:42.540] [INFO] usi - sid=1: < option name StringA type string default foo
[2024-05-31T17:42:42.541] [INFO] usi - sid=1: < option name StringB type string
[2024-05-31T17:42:42.541] [INFO] usi - sid=1: < option name CheckA type check default true
[2024-05-31T17:42:42.541] [INFO] usi - sid=1: < option name CheckB type check
[2024-05-31T17:42:42.541] [INFO] usi - sid=1: < usiok
[2024-05-31T17:42:42.542] [INFO] usi - sid=1: quit USI engine
[2024-05-31T17:42:42.542] [INFO] usi - sid=1: > quit
[2024-05-31T17:42:42.542] [INFO] usi - sid=1: engine process closed: close=undefined signal=undefined
[2024-05-31T17:42:42.543] [INFO] usi - sid=2: launch: path/to/engine
[2024-05-31T17:42:42.550] [INFO] usi - sid=2: > usi
[2024-05-31T17:42:42.551] [INFO] usi - sid=2: < usiok
[2024-05-31T17:42:42.551] [INFO] usi - sid=2: > setoption name myopt
[2024-05-31T17:42:42.551] [INFO] usi - sid=2: quit USI engine
[2024-05-31T17:42:42.552] [INFO] usi - sid=2: > quit
[2024-05-31T17:42:42.552] [INFO] usi - sid=2: engine process closed: close=undefined signal=undefined
[2024-05-31T17:42:42.553] [INFO] usi - sid=3: launch: /engines/engines
[2024-05-31T17:42:42.553] [INFO] usi - sid=3: > usi
[2024-05-31T17:42:42.553] [INFO] usi - sid=3: < usiok
[2024-05-31T17:42:42.554] [INFO] usi - sid=3: > isready
[2024-05-31T17:42:42.554] [INFO] usi - sid=3: < readyok
[2024-05-31T17:42:42.554] [INFO] usi - sid=3: > usinewgame
[2024-05-31T17:42:42.554] [INFO] usi - sid=3: > position startpos moves 7g7f 3c3d
[2024-05-31T17:42:42.554] [INFO] usi - sid=3: > go btime 37082 wtime 23103 byoyomi 10000
[2024-05-31T17:42:42.555] [INFO] usi - sid=3: < bestmove 2g2f ponder 8c8d
[2024-05-31T17:42:42.555] [INFO] usi - sid=3: > position startpos moves 7g7f 3c3d 2g2f
[2024-05-31T17:42:42.555] [INFO] usi - sid=3: > go btime 37082 wtime 23103 binc 0 winc 5000
[2024-05-31T17:42:42.555] [INFO] usi - sid=3: < bestmove 8c8d ponder 2f2e
[2024-05-31T17:42:42.556] [INFO] usi - sid=3: > position startpos moves 7g7f 3c3d 2g2f 8c8d
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
stderr | src/tests/command/common/arguments.spec.ts > command/common/arguments > not number
--num1 option must be a number: foo

stderr | src/tests/command/common/arguments.spec.ts > command/common/arguments > restrictions: list: error
--opt1 option must be one of: foo, bar

stderr | src/tests/command/common/arguments.spec.ts > command/common/arguments > restrictions: min: error
--num1 option must be greater than or equal to 100

stderr | src/tests/command/common/arguments.spec.ts > command/common/arguments > restrictions: max: error
--num1 option must be less than or equal to 200

stderr | src/tests/command/common/arguments.spec.ts > command/common/arguments > unknown option
Unknown option: --opt

 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/renderer/store/index.spec.ts (35) 377ms
 ✓ src/tests/background/usi/engine.spec.ts (8)
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/renderer/store/index.spec.ts (35) 377ms
 ✓ src/tests/background/usi/engine.spec.ts (8)
 ✓ src/tests/renderer/store/game.spec.ts (12)
 ✓ src/tests/renderer/store/record.spec.ts (16)
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/renderer/store/index.spec.ts (35) 377ms
 ✓ src/tests/background/usi/engine.spec.ts (8)
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/renderer/store/index.spec.ts (35) 377ms
 ✓ src/tests/background/usi/engine.spec.ts (8)
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/renderer/store/index.spec.ts (35) 377ms
 ✓ src/tests/background/usi/engine.spec.ts (8)
 ✓ src/tests/renderer/store/game.spec.ts (12)
 ✓ src/tests/renderer/store/record.spec.ts (16)
 ✓ src/tests/common/settings/usi.spec.ts (12)
 ✓ src/tests/background/file/conversion.spec.ts (2) 560ms
 ✓ src/tests/common/settings/csa.spec.ts (12)
 ✓ src/tests/background/version/version.spec.ts (10)
 ✓ src/tests/renderer/players/usi.spec.ts (3)
 ✓ src/tests/renderer/store/clock.spec.ts (3)
 ✓ src/tests/background/usi/index.spec.ts (4)
 ✓ src/tests/command/common/arguments.spec.ts (11)
 ✓ src/tests/renderer/helpers/path.spec.ts (11)
 ✓ src/tests/renderer/store/research.spec.ts (4)
 ✓ src/tests/renderer/helpers/record.spec.ts (1)
 ✓ src/tests/renderer/store/analysis.spec.ts (1)
 ✓ src/tests/background/file/history.spec.ts (1)
 ✓ src/tests/renderer/prompt/store.spec.ts (3)
 ✓ src/tests/common/settings/research.spec.ts (4)
 ✓ src/tests/common/settings/player.spec.ts (5)
 ✓ src/tests/background/log.spec.ts (4)
 ✓ src/tests/background/image/cropper.spec.ts (1) 315ms
 ✓ src/tests/common/settings/app.spec.ts (2)
 ✓ src/tests/renderer/store/setting.spec.ts (3)
 ✓ src/tests/common/advanced/command.spec.ts (1)
 ✓ src/tests/common/settings/window.spec.ts (2)
 · src/tests/renderer/view/board.spec.ts (1)
 · src/tests/background/window/security.spec.ts (4)
[2024-05-31T17:42:51.882] [ERROR] app - Error: 予期せぬイベントの送信元です。このエラーメッセージを開発者に報告してください。 [http://foo.bar/baz/qux.quux]
    at Module.validateIPCSender (/Users/paalon/git/electron-shogi/src/background/window/security.ts:18:13)
    at /Users/paalon/git/electron-shogi/src/tests/background/window/security.spec.ts:14:18
    at Proxy.assertThrows (/Users/paalon/git/electron-shogi/node_modules/chai/lib/chai/core/assertions.js:2644:7)
    at Proxy.methodWrapper (/Users/paalon/git/electron-shogi/node_modules/chai/lib/chai/utils/addMethod.js:57:25)
    at Proxy.<anonymous> (file:///Users/paalon/git/electron-shogi/node_modules/@vitest/expect/dist/index.js:850:16)
    at Proxy.overwritingMethodWrapper (/Users/paalon/git/electron-shogi/node_modules/chai/lib/chai/utils/overwriteMethod.js:78:33)
    at Proxy.<anonymous> (file:///Users/paalon/git/electron-shogi/node_modules/@vitest/expect/dist/index.js:1324:19)
    at Proxy.<anonymous> (file:///Users/paalon/git/electron-shogi/node_modules/@vitest/expect/dist/index.js:800:17)
    at Proxy.methodWrapper (/Users/paalon/git/electron-shogi/node_modules/chai/lib/chai/utils/addMethod.js:57:25)
    at /Users/paalon/git/electron-shogi/src/tests/background/window/security.spec.ts:14:84
[2024-05-31T17:42:51.889] [ERROR] app - Error: 予期せぬイベントの送信元です。このエラーメッセージを開発者に報告してください。 [https://localhost:1234/foo/bar.baz]
    at Module.validateIPCSender (/Users/paalon/git/electron-shogi/src/background/window/security.ts:18:13)
    at /Users/paalon/git/electron-shogi/src/tests/background/window/security.spec.ts:16:18
    at Proxy.assertThrows (/Users/paalon/git/electron-shogi/node_modules/chai/lib/chai/core/assertions.js:2644:7)
    at Proxy.methodWrapper (/Users/paalon/git/electron-shogi/node_modules/chai/lib/chai/utils/addMethod.js:57:25)
    at Proxy.<anonymous> (file:///Users/paalon/git/electron-shogi/node_modules/@vitest/expect/dist/index.js:850:16)
    at Proxy.overwritingMethodWrapper (/Users/paalon/git/electron-shogi/node_modules/chai/lib/chai/utils/overwriteMethod.js:78:33)
    at Proxy.<anonymous> (file:///Users/paalon/git/electron-shogi/node_modules/@vitest/expect/dist/index.js:1324:19)
    at Proxy.<anonymous> (file:///Users/paalon/git/electron-shogi/node_modules/@vitest/expect/dist/index.js:800:17)
    at Proxy.methodWrapper (/Users/paalon/git/electron-shogi/node_modules/chai/lib/chai/utils/addMethod.js:57:25)
    at /Users/paalon/git/electron-shogi/src/tests/background/window/security.spec.ts:16:91
[2024-05-31T17:42:51.893] [ERROR] app - Error: 予期せぬURLへのリクエストです。このエラーメッセージを開発者に報告してください。 [http://foo.bar/baz/qux.quux]
    at validateHTTPRequestURL (/Users/paalon/git/electron-shogi/src/background/window/security.ts:49:13)
    at Module.validateHTTPRequest (/Users/paalon/git/electron-shogi/src/background/window/security.ts:56:3)
    at /Users/paalon/git/electron-shogi/src/tests/background/window/security.spec.ts:28:18
    at Proxy.assertThrows (/Users/paalon/git/electron-shogi/node_modules/chai/lib/chai/core/assertions.js:2644:7)
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/background/csa/client.spec.ts (15) 398ms
 ✓ src/tests/renderer/store/csa.spec.ts (9)
 ✓ src/tests/renderer/store/index.spec.ts (35) 377ms
 ✓ src/tests/background/usi/engine.spec.ts (8)
 ✓ src/tests/renderer/store/game.spec.ts (12)
 ✓ src/tests/renderer/store/record.spec.ts (16)
 ✓ src/tests/common/settings/usi.spec.ts (12)
 ✓ src/tests/background/file/conversion.spec.ts (2) 560ms
 ✓ src/tests/common/settings/csa.spec.ts (12)
 ✓ src/tests/background/version/version.spec.ts (10)
 ✓ src/tests/renderer/players/usi.spec.ts (3)
 ✓ src/tests/renderer/store/clock.spec.ts (3)
 ✓ src/tests/background/usi/index.spec.ts (4)
 ✓ src/tests/command/common/arguments.spec.ts (11)
 ✓ src/tests/renderer/helpers/path.spec.ts (11)
 ✓ src/tests/renderer/store/research.spec.ts (4)
 ✓ src/tests/renderer/helpers/record.spec.ts (1)
 ✓ src/tests/renderer/store/analysis.spec.ts (1)
 ✓ src/tests/background/file/history.spec.ts (1)
 ✓ src/tests/renderer/prompt/store.spec.ts (3)
 ✓ src/tests/common/settings/research.spec.ts (4)
 ✓ src/tests/common/settings/player.spec.ts (5)
 ✓ src/tests/background/log.spec.ts (4)
 ✓ src/tests/background/image/cropper.spec.ts (1) 315ms
 ✓ src/tests/common/settings/app.spec.ts (2)
 ✓ src/tests/renderer/store/setting.spec.ts (3)
 ✓ src/tests/common/advanced/command.spec.ts (1)
 ✓ src/tests/common/settings/window.spec.ts (2)
 ✓ src/tests/renderer/view/board.spec.ts (1) 315ms
 ✓ src/tests/background/window/security.spec.ts (4)
 ✓ src/tests/common/settings/game.spec.ts (1)
 ✓ src/tests/renderer/players/builder.spec.ts (2)
 ✓ src/tests/background/proc/args.spec.ts (4)
 ✓ src/tests/common/helpers/string.spec.ts (2)
 ✓ src/tests/common/helpers/datetime.spec.ts (3)
 ✓ src/tests/common/settings/analysis.spec.ts (1)

 Test Files  36 passed (36)
      Tests  213 passed (213)
   Start at  17:42:33
   Duration  21.80s (transform 2.07s, setup 4ms, collect 9.50s, tests 3.38s, environment 38.28s, prepare 6.99s)

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal path configuration for module resolution. No impact on end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->