### PR TITLE
fix precision

### DIFF
--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -96,22 +96,22 @@ function getMessageAttachmentsByGameResults(results: GameResults): Attachment[] 
         {
           text: `${t.eloRatingDiff} (${t.ignoreDraws})`,
           children: [
-            `${statistics.rating.toPrecision(6)}`,
-            `95% CI: [${statistics.ratingLower.toPrecision(6)}, ${statistics.ratingUpper.toPrecision(6)}]`,
+            `${statistics.rating.toFixed(2)}`,
+            `95% CI: [${statistics.ratingLower.toFixed(1)}, ${statistics.ratingUpper.toFixed(1)}]`,
           ],
         },
         {
           text: `${t.eloRatingDiff} (${t.drawsAreHalfWin})`,
           children: [
-            `${statistics.ratingWithDraw.toPrecision(6)}`,
-            `95% CI: [${statistics.ratingWithDrawLower.toPrecision(6)}, ${statistics.ratingWithDrawUpper.toPrecision(6)}]`,
+            `${statistics.ratingWithDraw.toFixed(2)}`,
+            `95% CI: [${statistics.ratingWithDrawLower.toFixed(1)}, ${statistics.ratingWithDrawUpper.toFixed(1)}]`,
           ],
         },
         {
           text: "二項検定",
           children: [
             `np > 5: ${statistics.npIsGreaterThan5 ? "True" : "False"}`,
-            `${t.zValue}: ${statistics.zValue.toPrecision(5)}`,
+            `${t.zValue}: ${statistics.zValue.toFixed(2)}`,
             `${t.significance5pc}: ${statistics.significance5pc ? "True" : "False"}`,
             `${t.significance1pc}: ${statistics.significance1pc ? "True" : "False"}`,
           ],


### PR DESCRIPTION
# 説明 / Description

統計情報の表示桁数を調整

関連 #839

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Enhanced the display of numerical values for statistics by updating the formatting to fixed decimal places for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->