### PR TITLE
リリース版で DevTools を開いた時のエラーを修正

### DIFF
--- a/src/background/window/security.ts
+++ b/src/background/window/security.ts
@@ -33,7 +33,7 @@ const allowedHTTPRequestURLs = [
   { protocol: "http:", host: /^localhost:[0-9]+$/ },
   { protocol: "ws:", host: /^localhost:[0-9]+$/ },
   { protocol: "file:", host: /^$/ },
-  { protocol: "devtools:", host: /^devtools$/ },
+  { protocol: "devtools:" },
 ];
 
 function validateHTTPRequestURL(url: string) {
@@ -42,7 +42,7 @@ function validateHTTPRequestURL(url: string) {
   }
   const u = new URL(url);
   for (const allowed of allowedHTTPRequestURLs) {
-    if (u.protocol === allowed.protocol && allowed.host.test(u.host)) {
+    if (u.protocol === allowed.protocol && (!allowed.host || allowed.host.test(u.host))) {
       return;
     }
   }

--- a/src/tests/background/window/security.spec.ts
+++ b/src/tests/background/window/security.spec.ts
@@ -21,6 +21,7 @@ describe("security", () => {
     validateHTTPRequest("GET", "ws://localhost:1234/foo/bar.baz");
     validateHTTPRequest("GET", "file:///home/shogi/apps/electron-shogi/assets.asr");
     validateHTTPRequest("GET", "devtools://devtools/bundled/index.html");
+    validateHTTPRequest("GET", "devtools://foo/bar/baz.qux");
   });
 
   it("validateHTTPRequest/notAllowed", () => {
@@ -28,7 +29,5 @@ describe("security", () => {
     expect(() => validateHTTPRequest("GET", "http://foo.bar/baz/qux.quux")).toThrow();
     // https will not used with localhost
     expect(() => validateHTTPRequest("GET", "https://localhost:1234/foo/bar.baz")).toThrow();
-    // unexpected devtools URL
-    expect(() => validateHTTPRequest("GET", "devtools://foo/bar/baz.qux")).toThrow();
   });
 });


### PR DESCRIPTION
# 説明 / Description

#845

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated URL validation logic to allow `devtools:` protocol without a specified host.
  - Reintroduced validation check for specific `devtools` URLs in the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->