### PR TITLE
Fix for engines provided by .bat file and .cmd file

### DIFF
--- a/src/background/usi/process.ts
+++ b/src/background/usi/process.ts
@@ -2,12 +2,19 @@ import { spawn, ChildProcessWithoutNullStreams } from "node:child_process";
 import { createInterface as readline, Interface as Readline } from "node:readline";
 import path from "node:path";
 
+const isWin = process.platform === "win32";
+
 export class ChildProcess {
   private handle: ChildProcessWithoutNullStreams;
   private readline: Readline | null = null;
 
   constructor(cmd: string) {
-    this.handle = spawn(cmd, {
+    let args = [] as string[];
+    if (isWin && (cmd.endsWith(".bat") || cmd.endsWith(".cmd"))) {
+      args = ["/c", cmd];
+      cmd = "cmd";
+    }
+    this.handle = spawn(cmd, args, {
       cwd: path.dirname(cmd),
     }).on("close", this.onClose.bind(this));
   }


### PR DESCRIPTION
# 説明 / Description

https://github.com/sunfish-shogi/electron-shogi/issues/855

.bat や .cmd を呼び出す場合に [Node.js のドキュメント](https://nodejs.org/docs/latest-v20.x/api/child_process.html#spawning-bat-and-cmd-files-on-windows) に記載された方法に従うように修正します。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced compatibility for Windows by adjusting command execution logic based on the operating system and file extensions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->