### PR TITLE
Implements open new instance feature for MacOS

### DIFF
--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -5,6 +5,7 @@ export const en: Texts = {
   shogiHome: "ShogiHome",
   clear: "Clear",
   open: "Open",
+  openNewInstance: "Open a New ShogiHome Instance",
   saveOverwrite: "Overwrite",
   newRecord: "New Record",
   openRecord: "Open Record",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -4,6 +4,7 @@ export const ja: Texts = {
   shogiHome: "ShogiHome",
   clear: "初期化",
   open: "開く",
+  openNewInstance: "新しい ShogiHome ウィンドウを開く",
   saveOverwrite: "上書き保存",
   newRecord: "新規棋譜",
   openRecord: "棋譜を開く",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -4,6 +4,7 @@ export const zh_tw: Texts = {
   shogiHome: "ShogiHome",
   clear: "清除",
   open: "開啟",
+  openNewInstance: "開啟新的 ShogiHome 視窗",
   saveOverwrite: "覆蓋檔案",
   newRecord: "新棋譜",
   openRecord: "打開棋譜",

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -2,6 +2,7 @@ export type Texts = {
   shogiHome: string;
   clear: string;
   open: string;
+  openNewInstance: string;
   saveOverwrite: string;
   newRecord: string;
   openRecord: string;


### PR DESCRIPTION
# 説明 / Description

This PR is about the implementation of #6 by using `open -jn` command to force MacOS to open a new instance of ShogiHome. 
The trigger button will be shown at the dock's app button, where most of the apps put their "open new window" button at. 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST (for Outside Contributor)
  - [x] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [x] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to open a new instance of the app via a dock menu on MacOS.
  - Introduced localized text for the new feature in English, Japanese, and Traditional Chinese.
  
- **Localization**
  - New text keys added for "Open a New ShogiHome Instance" in English, Japanese, and Traditional Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->