### PR TITLE
成・不成選択表示のドラッグ抑止

### DIFF
--- a/src/renderer/view/primitive/BoardView.vue
+++ b/src/renderer/view/primitive/BoardView.vue
@@ -99,10 +99,10 @@
       </div>
       <div v-if="layout.promotion" class="promotion-selector" :style="layout.promotion.style">
         <div class="select-button promote" @click.stop.prevent="clickPromote()">
-          <img class="piece-image" :src="layout.promotion.promoteImagePath" />
+          <img class="piece-image" :src="layout.promotion.promoteImagePath" draggable="false" />
         </div>
         <div class="select-button not-promote" @click.stop.prevent="clickNotPromote()">
-          <img class="piece-image" :src="layout.promotion.notPromoteImagePath" />
+          <img class="piece-image" :src="layout.promotion.notPromoteImagePath" draggable="false" />
         </div>
       </div>
       <div class="turn" :style="layout.turn.style">{{ nextMoveLabel }}</div>


### PR DESCRIPTION
# 説明 / Description

#866 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Modified piece promotion images to be non-draggable, ensuring a smoother user experience when selecting promotion options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->