### PR TITLE
Add compact control box

### DIFF
--- a/src/renderer/view/main/BoardPane.vue
+++ b/src/renderer/view/main/BoardPane.vue
@@ -33,12 +33,14 @@
       <template #right-control>
         <ControlPane
           v-show="rightControlType !== RightSideControlType.NONE"
+          class="full"
           :group="ControlGroup.Group1"
         />
       </template>
       <template #left-control>
         <ControlPane
           v-show="leftControlType !== LeftSideControlType.NONE"
+          class="full"
           :group="ControlGroup.Group2"
         />
       </template>

--- a/src/renderer/view/main/ControlPane.vue
+++ b/src/renderer/view/main/ControlPane.vue
@@ -1,213 +1,221 @@
 <template>
-  <div ref="root" class="full">
-    <div v-show="group === ControlGroup.Group1" class="full column control-box">
-      <!-- 検討 -->
-      <button
-        v-show="store.researchState !== ResearchState.RUNNING"
-        class="control-item"
-        data-hotkey="Mod+r"
-        @click="onResearch"
+  <div>
+    <div ref="root" class="full column" :class="{ compact }">
+      <div
+        v-show="group === ControlGroup.Group1 || group === ControlGroup.All"
+        class="full column control-box"
       >
-        <Icon :icon="IconType.RESEARCH" />
-        <span>{{ t.research }}</span>
-      </button>
-      <!-- 検討終了 -->
-      <button
-        v-show="store.researchState === ResearchState.RUNNING"
-        class="control-item close"
-        data-hotkey="Escape"
-        @click="onEndResearch"
+        <!-- 検討 -->
+        <button
+          v-show="store.researchState !== ResearchState.RUNNING"
+          class="control-item"
+          data-hotkey="Mod+r"
+          @click="onResearch"
+        >
+          <Icon :icon="IconType.RESEARCH" />
+          <span :class="{ tooltip: compact }">{{ t.research }}</span>
+        </button>
+        <!-- 検討終了 -->
+        <button
+          v-show="store.researchState === ResearchState.RUNNING"
+          class="control-item close"
+          data-hotkey="Escape"
+          @click="onEndResearch"
+        >
+          <Icon :icon="IconType.END" />
+          <span :class="{ tooltip: compact }">{{ t.endResearch }}</span>
+        </button>
+        <!-- 対局 -->
+        <button v-show="store.appState === AppState.NORMAL" class="control-item" @click="onGame">
+          <Icon :icon="IconType.GAME" />
+          <span :class="{ tooltip: compact }">{{ t.game }}</span>
+        </button>
+        <!-- 対局中断 -->
+        <button
+          v-show="store.appState === AppState.GAME || store.appState === AppState.CSA_GAME"
+          class="control-item close"
+          data-hotkey="Escape"
+          @click="onStop"
+        >
+          <Icon :icon="IconType.STOP" />
+          <span :class="{ tooltip: compact }">{{ t.stopGame }}</span>
+        </button>
+        <!-- 勝ち宣言 -->
+        <button
+          v-show="
+            store.isMovableByUser &&
+            (store.appState === AppState.CSA_GAME ||
+              (store.appState === AppState.GAME &&
+                DeclarableJishogiRules.includes(store.gameSettings.jishogiRule)))
+          "
+          class="control-item close"
+          @click="onWin"
+        >
+          <Icon :icon="IconType.CALL" />
+          <span :class="{ tooltip: compact }">{{ t.declareWin }}</span>
+        </button>
+        <!-- 投了 -->
+        <button
+          v-show="
+            (store.appState === AppState.GAME || store.appState === AppState.CSA_GAME) &&
+            store.isMovableByUser
+          "
+          class="control-item close"
+          @click="onResign"
+        >
+          <Icon :icon="IconType.RESIGN" />
+          <span :class="{ tooltip: compact }">{{ t.resign }}</span>
+        </button>
+        <!-- 持将棋の点数 -->
+        <button
+          v-show="store.appState === AppState.GAME || store.appState === AppState.CSA_GAME"
+          class="control-item"
+          @click="onJishogiPoints"
+        >
+          <Icon :icon="IconType.QUESTION" />
+          <span :class="{ tooltip: compact }">{{ t.jishogiPoints }}</span>
+        </button>
+        <!-- 戦績確認 -->
+        <button
+          v-show="store.appState === AppState.GAME && store.gameSettings.repeat >= 2"
+          class="control-item"
+          @click="onShowGameResults"
+        >
+          <Icon :icon="IconType.SCORE" />
+          <span :class="{ tooltip: compact }">{{ t.displayGameResults }}</span>
+        </button>
+        <!-- 解析 -->
+        <button
+          v-show="store.appState === AppState.NORMAL"
+          class="control-item"
+          data-hotkey="Mod+a"
+          @click="onAnalysis"
+        >
+          <Icon :icon="IconType.ANALYSIS" />
+          <span :class="{ tooltip: compact }">{{ t.analysis }}</span>
+        </button>
+        <!-- 解析中断 -->
+        <button
+          v-show="store.appState === AppState.ANALYSIS"
+          class="control-item close"
+          data-hotkey="Escape"
+          @click="onEndAnalysis"
+        >
+          <Icon :icon="IconType.STOP" />
+          <span :class="{ tooltip: compact }">{{ t.stopAnalysis }}</span>
+        </button>
+        <!-- 詰み探索 -->
+        <button
+          v-show="store.appState === AppState.NORMAL"
+          class="control-item"
+          data-hotkey="Mod+m"
+          @click="onMateSearch"
+        >
+          <Icon :icon="IconType.MATE_SEARCH" />
+          <span :class="{ tooltip: compact }">{{ t.mateSearch }}</span>
+        </button>
+        <!-- 詰み探索終了 -->
+        <button
+          v-show="store.appState === AppState.MATE_SEARCH"
+          class="control-item close"
+          data-hotkey="Escape"
+          @click="onStopMateSearch"
+        >
+          <Icon :icon="IconType.END" />
+          <span :class="{ tooltip: compact }">{{ t.stopMateSearch }}</span>
+        </button>
+        <!-- 局面編集 -->
+        <button
+          v-show="store.appState === AppState.NORMAL"
+          class="control-item"
+          @click="onStartEditPosition"
+        >
+          <Icon :icon="IconType.EDIT" />
+          <span :class="{ tooltip: compact }">{{ t.setupPosition }}</span>
+        </button>
+        <!-- 盤面編集終了 -->
+        <button
+          v-show="store.appState === AppState.POSITION_EDITING"
+          class="control-item close"
+          data-hotkey="Escape"
+          @click="onEndEditPosition"
+        >
+          <Icon :icon="IconType.CHECK" />
+          <span :class="{ tooltip: compact }">{{ t.completePositionSetup }}</span>
+        </button>
+        <!-- 手番変更 -->
+        <button
+          v-show="store.appState === AppState.POSITION_EDITING"
+          class="control-item"
+          @click="onChangeTurn"
+        >
+          <Icon :icon="IconType.SWAP" />
+          <span :class="{ tooltip: compact }">{{ t.changeTurn }}</span>
+        </button>
+        <!-- 局面の初期化 -->
+        <button
+          v-show="store.appState === AppState.POSITION_EDITING"
+          class="control-item"
+          @click="onInitPosition"
+        >
+          <span :class="{ tooltip: compact }">{{ t.initializePosition }}</span>
+        </button>
+        <!-- 駒の増減 -->
+        <button
+          v-show="store.appState === AppState.POSITION_EDITING"
+          class="control-item"
+          @click="onPieceSetChange"
+        >
+          <span :class="{ tooltip: compact }">{{ t.changePieceSet }}</span>
+        </button>
+      </div>
+      <div
+        v-show="group === ControlGroup.Group2 || group === ControlGroup.All"
+        class="full column control-box"
       >
-        <Icon :icon="IconType.END" />
-        <span>{{ t.endResearch }}</span>
-      </button>
-      <!-- 対局 -->
-      <button v-show="store.appState === AppState.NORMAL" class="control-item" @click="onGame">
-        <Icon :icon="IconType.GAME" />
-        <span>{{ t.game }}</span>
-      </button>
-      <!-- 対局中断 -->
-      <button
-        v-show="store.appState === AppState.GAME || store.appState === AppState.CSA_GAME"
-        class="control-item close"
-        data-hotkey="Escape"
-        @click="onStop"
-      >
-        <Icon :icon="IconType.STOP" />
-        <span>{{ t.stopGame }}</span>
-      </button>
-      <!-- 勝ち宣言 -->
-      <button
-        v-show="
-          store.isMovableByUser &&
-          (store.appState === AppState.CSA_GAME ||
-            (store.appState === AppState.GAME &&
-              DeclarableJishogiRules.includes(store.gameSettings.jishogiRule)))
-        "
-        class="control-item close"
-        @click="onWin"
-      >
-        <Icon :icon="IconType.CALL" />
-        <span>{{ t.declareWin }}</span>
-      </button>
-      <!-- 投了 -->
-      <button
-        v-show="
-          (store.appState === AppState.GAME || store.appState === AppState.CSA_GAME) &&
-          store.isMovableByUser
-        "
-        class="control-item close"
-        @click="onResign"
-      >
-        <Icon :icon="IconType.RESIGN" />
-        <span>{{ t.resign }}</span>
-      </button>
-      <!-- 持将棋の点数 -->
-      <button
-        v-show="store.appState === AppState.GAME || store.appState === AppState.CSA_GAME"
-        class="control-item"
-        @click="onJishogiPoints"
-      >
-        <Icon :icon="IconType.QUESTION" />
-        <span>{{ t.jishogiPoints }}</span>
-      </button>
-      <!-- 戦績確認 -->
-      <button
-        v-show="store.appState === AppState.GAME && store.gameSettings.repeat >= 2"
-        class="control-item"
-        @click="onShowGameResults"
-      >
-        <Icon :icon="IconType.SCORE" />
-        <span>{{ t.displayGameResults }}</span>
-      </button>
-      <!-- 解析 -->
-      <button
-        v-show="store.appState === AppState.NORMAL"
-        class="control-item"
-        data-hotkey="Mod+a"
-        @click="onAnalysis"
-      >
-        <Icon :icon="IconType.ANALYSIS" />
-        <span>{{ t.analysis }}</span>
-      </button>
-      <!-- 解析中断 -->
-      <button
-        v-show="store.appState === AppState.ANALYSIS"
-        class="control-item close"
-        data-hotkey="Escape"
-        @click="onEndAnalysis"
-      >
-        <Icon :icon="IconType.STOP" />
-        <span>{{ t.stopAnalysis }}</span>
-      </button>
-      <!-- 詰み探索 -->
-      <button
-        v-show="store.appState === AppState.NORMAL"
-        class="control-item"
-        data-hotkey="Mod+m"
-        @click="onMateSearch"
-      >
-        <Icon :icon="IconType.MATE_SEARCH" />
-        <span>{{ t.mateSearch }}</span>
-      </button>
-      <!-- 詰み探索終了 -->
-      <button
-        v-show="store.appState === AppState.MATE_SEARCH"
-        class="control-item close"
-        data-hotkey="Escape"
-        @click="onStopMateSearch"
-      >
-        <Icon :icon="IconType.END" />
-        <span>{{ t.stopMateSearch }}</span>
-      </button>
-      <!-- 局面編集 -->
-      <button
-        v-show="store.appState === AppState.NORMAL"
-        class="control-item"
-        @click="onStartEditPosition"
-      >
-        <Icon :icon="IconType.EDIT" />
-        <span>{{ t.setupPosition }}</span>
-      </button>
-      <!-- 盤面編集終了 -->
-      <button
-        v-show="store.appState === AppState.POSITION_EDITING"
-        class="control-item close"
-        data-hotkey="Escape"
-        @click="onEndEditPosition"
-      >
-        <Icon :icon="IconType.CHECK" />
-        <span>{{ t.completePositionSetup }}</span>
-      </button>
-      <!-- 手番変更 -->
-      <button
-        v-show="store.appState === AppState.POSITION_EDITING"
-        class="control-item"
-        @click="onChangeTurn"
-      >
-        <Icon :icon="IconType.SWAP" />
-        <span>{{ t.changeTurn }}</span>
-      </button>
-      <!-- 局面の初期化 -->
-      <button
-        v-show="store.appState === AppState.POSITION_EDITING"
-        class="control-item"
-        @click="onInitPosition"
-      >
-        <span>{{ t.initializePosition }}</span>
-      </button>
-      <!-- 駒の増減 -->
-      <button
-        v-show="store.appState === AppState.POSITION_EDITING"
-        class="control-item"
-        @click="onPieceSetChange"
-      >
-        <span>{{ t.changePieceSet }}</span>
-      </button>
+        <!-- 指し手削除 -->
+        <button
+          class="control-item"
+          data-hotkey="Mod+d"
+          :disabled="store.appState !== AppState.NORMAL"
+          @click="onRemoveCurrentMove"
+        >
+          <Icon :icon="IconType.DELETE" />
+          <span :class="{ tooltip: compact }">{{ t.deleteMove }}</span>
+        </button>
+        <!-- ファイル -->
+        <button class="control-item" @click="onFileAction">
+          <Icon :icon="IconType.FILE" />
+          <span :class="{ tooltip: compact }">{{ t.file }}</span>
+        </button>
+        <!-- 盤面反転 -->
+        <button class="control-item" data-hotkey="Mod+t" @click="onFlip">
+          <Icon :icon="IconType.FLIP" />
+          <span :class="{ tooltip: compact }">{{ t.flipBoard }}</span>
+        </button>
+        <!-- エンジン設定 -->
+        <button
+          class="control-item"
+          data-hotkey="Mod+."
+          :disabled="store.appState !== AppState.NORMAL"
+          @click="onOpenEngines"
+        >
+          <Icon :icon="IconType.ENGINE_SETTINGS" />
+          <span :class="{ tooltip: compact }">{{ t.manageEngines }}</span>
+        </button>
+        <!-- アプリ設定 -->
+        <button class="control-item" data-hotkey="Mod+," @click="onOpenAppSettings">
+          <Icon :icon="IconType.SETTINGS" />
+          <span :class="{ tooltip: compact }">{{ t.appSettings }}</span>
+        </button>
+      </div>
+      <GameMenu v-if="isGameMenuVisible" @close="isGameMenuVisible = false" />
+      <FileMenu v-if="isFileMenuVisible" @close="isFileMenuVisible = false" />
+      <InitialPositionMenu
+        v-if="isInitialPositionMenuVisible"
+        @close="isInitialPositionMenuVisible = false"
+      />
     </div>
-    <div v-show="group === ControlGroup.Group2" class="full column control-box">
-      <!-- 指し手削除 -->
-      <button
-        class="control-item"
-        data-hotkey="Mod+d"
-        :disabled="store.appState !== AppState.NORMAL"
-        @click="onRemoveCurrentMove"
-      >
-        <Icon :icon="IconType.DELETE" />
-        <span>{{ t.deleteMove }}</span>
-      </button>
-      <!-- ファイル -->
-      <button class="control-item" @click="onFileAction">
-        <Icon :icon="IconType.FILE" />
-        <span>{{ t.file }}</span>
-      </button>
-      <!-- 盤面反転 -->
-      <button class="control-item" data-hotkey="Mod+t" @click="onFlip">
-        <Icon :icon="IconType.FLIP" />
-        <span>{{ t.flipBoard }}</span>
-      </button>
-      <!-- エンジン設定 -->
-      <button
-        class="control-item"
-        data-hotkey="Mod+."
-        :disabled="store.appState !== AppState.NORMAL"
-        @click="onOpenEngines"
-      >
-        <Icon :icon="IconType.ENGINE_SETTINGS" />
-        <span>{{ t.manageEngines }}</span>
-      </button>
-      <!-- アプリ設定 -->
-      <button class="control-item" data-hotkey="Mod+," @click="onOpenAppSettings">
-        <Icon :icon="IconType.SETTINGS" />
-        <span>{{ t.appSettings }}</span>
-      </button>
-    </div>
-    <GameMenu v-if="isGameMenuVisible" @close="isGameMenuVisible = false" />
-    <FileMenu v-if="isFileMenuVisible" @close="isFileMenuVisible = false" />
-    <InitialPositionMenu
-      v-if="isInitialPositionMenuVisible"
-      @close="isInitialPositionMenuVisible = false"
-    />
   </div>
 </template>
 
@@ -215,6 +223,7 @@
 export enum ControlGroup {
   Group1,
   Group2,
+  All,
 }
 </script>
 
@@ -241,6 +250,10 @@ defineProps({
   group: {
     type: Number as PropType<ControlGroup>,
     required: true,
+  },
+  compact: {
+    type: Boolean,
+    default: false,
   },
 });
 
@@ -370,7 +383,26 @@ const onRemoveCurrentMove = () => {
   line-height: 200%;
   padding: 0 5% 0 5%;
 }
+.compact .control-item {
+  text-align: center;
+}
 .control-item .icon {
   height: 68%;
+}
+.compact .control-item .icon {
+  height: 48%;
+}
+.tooltip {
+  display: none;
+  position: absolute;
+  color: var(--main-color);
+  background-color: var(--main-bg-color);
+  border: 1px solid var(--main-color);
+  border-radius: 5px;
+  padding: 5px;
+  z-index: 100;
+}
+*:hover > .tooltip {
+  display: block;
 }
 </style>

--- a/src/renderer/view/main/CustomLayout.vue
+++ b/src/renderer/view/main/CustomLayout.vue
@@ -52,8 +52,16 @@
         :show-bookmark="!!c.showBookmark"
       />
       <RecordInfo v-else-if="c.type === 'RecordInfo'" class="full" :size="c.rect.size" />
-      <ControlPane v-else-if="c.type === 'ControlGroup1'" :group="ControlGroup.Group1" />
-      <ControlPane v-else-if="c.type === 'ControlGroup2'" :group="ControlGroup.Group2" />
+      <ControlPane
+        v-else-if="c.type === 'ControlGroup1'"
+        class="full"
+        :group="ControlGroup.Group1"
+      />
+      <ControlPane
+        v-else-if="c.type === 'ControlGroup2'"
+        class="full"
+        :group="ControlGroup.Group2"
+      />
     </div>
   </div>
 </template>

--- a/src/renderer/view/main/StandardLayout.vue
+++ b/src/renderer/view/main/StandardLayout.vue
@@ -10,6 +10,12 @@
       <Pane :size="topPaneHeightPercentage">
         <div class="full column">
           <div class="row">
+            <ControlPane
+              v-if="appSettings.boardLayoutType !== BoardLayoutType.STANDARD"
+              class="compact-control"
+              :group="ControlGroup.All"
+              :compact="true"
+            />
             <BoardPane
               :style="boardPaneStyle"
               :max-size="boardPaneMaxSize"
@@ -92,8 +98,10 @@ import { reactive, onMounted, onUnmounted, computed, ref } from "vue";
 import BoardPane from "./BoardPane.vue";
 import RecordPane, { minWidth as minRecordWidth } from "./RecordPane.vue";
 import TabPane, { headerHeight as tabHeaderHeight } from "./TabPane.vue";
+import ControlPane, { ControlGroup } from "./ControlPane.vue";
 import { RectSize } from "@/common/assets/geometry";
 import { AppSettingsUpdate, Tab, TabPaneType } from "@/common/settings/app";
+import { BoardLayoutType } from "@/common/settings/layout";
 import api from "@/renderer/ipc/api";
 import { LogLevel } from "@/common/log";
 import { toString } from "@/common/helpers/string";
@@ -264,6 +272,10 @@ const tabPaneSize2 = computed(() => {
 </style>
 
 <style scoped>
+.compact-control {
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
 .unhide-tabview-button {
   width: 100%;
   height: 30px;


### PR DESCRIPTION
# 説明 / Description

盤面のタイプがコンパクトやポートレイトの場合に、左側に小幅ののコントロールパネルを表示する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced `ControlPane` functionality with the addition of an `All` control group for improved categorization.
  - Introduced a `compact` layout option for better usability and visual clarity in the interface.
  - Added tooltip functionality for buttons to reduce visual clutter and improve interactivity.
  - Conditional rendering of `ControlPane` based on user settings, allowing for a responsive layout.

- **Bug Fixes**
  - Improved visibility conditions for various buttons, ensuring they appear correctly based on application state.

- **Style**
  - Implemented new CSS rules for the `compact` view, enhancing alignment and presentation of controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->