### PR TITLE
Remove SHOGI-EXTEND and Kyokumen-pedia

### DIFF
--- a/src/common/links/mogproject.ts
+++ b/src/common/links/mogproject.ts
@@ -7,6 +7,7 @@ import {
 const shogiPlaygroundBaseURL = "https://play.mogproject.com";
 
 export function shogiPlaygroundURL(record: ImmutableRecord, flip: boolean = false): string {
+  // クエリ仕様: https://github.com/mogproject/mog-playground/wiki/Query-Parameters
   const [usen, branch] = record.usen;
   const move = branch === 0 ? record.current.ply : `${branch}.${record.current.ply}`;
   const bn = encodeURIComponent(getBlackPlayerNamePreferShort(record.metadata) || "");

--- a/src/common/links/piyoshogi.ts
+++ b/src/common/links/piyoshogi.ts
@@ -3,6 +3,7 @@ import { ImmutableRecord } from "tsshogi";
 const piyoShogiBaseURL = "https://www.studiok-i.net/kifu/";
 
 export function piyoShogiURL(record: ImmutableRecord): string {
+  // URL仕様: https://www.studiok-i.net/android/piyo_shogi_link.html
   const sfen = record.getUSI({
     startpos: true,
     resign: true,

--- a/src/renderer/view/dialog/ShareDialog.vue
+++ b/src/renderer/view/dialog/ShareDialog.vue
@@ -33,11 +33,9 @@ import { mobileWebAppURL } from "@/common/links/github";
 import api from "@/renderer/ipc/api";
 import { IconType } from "@/renderer/assets/icons";
 import Icon from "@/renderer/view/primitive/Icon.vue";
-import { shogiExtendSharedBoardURL } from "@/common/links/shogiextend";
 import { shogiPlaygroundURL } from "@/common/links/mogproject";
 import { useAppSettings } from "@/renderer/store/settings";
 import { piyoShogiURL } from "@/common/links/piyoshogi";
-import { kyokumenpediaURL } from "@/common/links/kyokumenpedia";
 
 const store = useStore();
 const appSettings = useAppSettings();
@@ -62,18 +60,20 @@ const list = computed(() => {
       label: "Shogi Playground",
       url: shogiPlaygroundURL(store.record, appSettings.boardFlipping),
     },
-    {
-      label: "SHOGI-EXTEND",
-      url: shogiExtendSharedBoardURL(store.record),
-    },
+    // NOTE: 公式な文書で仕様への言及がないので除外する。
+    //{
+    //  label: "SHOGI-EXTEND",
+    //  url: shogiExtendSharedBoardURL(store.record),
+    //},
     {
       label: "ぴよ将棋",
       url: piyoShogiURL(store.record),
     },
-    {
-      label: "局面ぺディア",
-      url: kyokumenpediaURL(store.record.position),
-    },
+    // NOTE: 公式な文書で仕様への言及がないので除外する。
+    //{
+    //  label: "局面ぺディア",
+    //  url: kyokumenpediaURL(store.record.position),
+    //},
   ];
 });
 


### PR DESCRIPTION
# 説明 / Description

SHOGI-EXTEND と局面ぺディアは URL の仕様について公式に言及されていないので、シェア機能から除外する。

関連: #923 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added comments to improve understanding of the `shogiPlaygroundURL` and `piyoShogiURL` functions.

- **User Interface Changes**
	- Removed "SHOGI-EXTEND" and "局面ぺディア" from the ShareDialog options, altering the resources available to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->