### PR TITLE
Update reset feature for mobile app

### DIFF
--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -987,15 +987,17 @@ class Store {
   }
 
   initializePositionBySFEN(sfen: string): void {
-    if (this.appState != AppState.POSITION_EDITING) {
-      return;
+    if (this.appState === AppState.NORMAL || this.appState === AppState.POSITION_EDITING) {
+      this.showConfirmation({
+        message:
+          this.appState === AppState.NORMAL
+            ? t.areYouSureWantToClearRecord
+            : t.areYouSureWantToDiscardPosition,
+        onOk: () => {
+          this.recordManager.resetBySFEN(sfen);
+        },
+      });
     }
-    this.showConfirmation({
-      message: t.areYouSureWantToDiscardPosition,
-      onOk: () => {
-        this.recordManager.resetBySFEN(sfen);
-      },
-    });
   }
 
   changeTurn(): void {

--- a/src/renderer/view/menu/FileMenu.vue
+++ b/src/renderer/view/menu/FileMenu.vue
@@ -96,6 +96,7 @@
         </button>
       </div>
     </dialog>
+    <InitialPositionMenu v-if="isInitialPositionMenuVisible" @close="emit('close')" />
   </div>
 </template>
 
@@ -111,6 +112,7 @@ import api, { isMobileWebApp, isNative } from "@/renderer/ipc/api";
 import { useAppSettings } from "@/renderer/store/settings";
 import { installHotKeyForDialog, uninstallHotKeyForDialog } from "@/renderer/devices/hotkey";
 import { openCopyright } from "@/renderer/helpers/copyright";
+import InitialPositionMenu from "@/renderer/view/menu/InitialPositionMenu.vue";
 
 const emit = defineEmits<{
   close: [];
@@ -119,6 +121,7 @@ const emit = defineEmits<{
 const store = useStore();
 const appSettings = useAppSettings();
 const dialog = ref();
+const isInitialPositionMenuVisible = ref(false);
 const onClose = () => {
   emit("close");
 };
@@ -134,8 +137,12 @@ const onFlip = () => {
   emit("close");
 };
 const onNewFile = () => {
-  store.resetRecord();
-  emit("close");
+  if (isMobileWebApp()) {
+    isInitialPositionMenuVisible.value = true;
+  } else {
+    store.resetRecord();
+    emit("close");
+  }
 };
 const onOpen = () => {
   store.openRecord();


### PR DESCRIPTION
# 説明 / Description

mobile 版で初期局面の手合いを変更できるようにする。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a confirmation dialog for clearing records or discarding positions based on the application's state.
	- Introduced an `InitialPositionMenu` for mobile users to enhance the file menu experience.

- **Improvements**
	- Enhanced user interaction by providing additional confirmation prompts, improving overall control and experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->