### PR TITLE
棋譜情報に「記録係」を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12676,9 +12676,9 @@
       "license": "0BSD"
     },
     "node_modules/tsshogi": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/tsshogi/-/tsshogi-1.1.2.tgz",
-      "integrity": "sha512-LsJiRvLBMm9LTCfLiPbdLbMt+nXL5fHz7fUNWUgPSguyBxsA+oiPp1IJ1xY9DYb92mGxB0yKYf9xzntbcU42rg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tsshogi/-/tsshogi-1.2.0.tgz",
+      "integrity": "sha512-3bN6xwwWA3oZ1Fza0XZTkKGQsgr5u+odwKt4UpPU23XD4CNLftRvHRHXtG5ggqBn2C9DVp9+b35ow2MzUzwR+Q==",
       "license": "MIT"
     },
     "node_modules/type-check": {

--- a/src/common/i18n/locales/en.ts
+++ b/src/common/i18n/locales/en.ts
@@ -388,6 +388,7 @@ export const en: Texts = {
   note: "Note",
   senteShortName: "Sente(short)",
   goteShortName: "Gote(short)",
+  scorekeeper: "Scorekeeper",
   opusNo: "Opus No.",
   opusName: "Opus Name",
   publishedBy: "Published By",

--- a/src/common/i18n/locales/ja.ts
+++ b/src/common/i18n/locales/ja.ts
@@ -388,6 +388,7 @@ export const ja: Texts = {
   note: "備考",
   senteShortName: "先手省略名",
   goteShortName: "後手省略名",
+  scorekeeper: "記録係",
   opusNo: "作品番号",
   opusName: "作品名",
   publishedBy: "発表誌",

--- a/src/common/i18n/locales/vi.ts
+++ b/src/common/i18n/locales/vi.ts
@@ -388,6 +388,7 @@ export const vi: Texts = {
   note: "Ghi chú",
   senteShortName: "Tiên thủ (ngắn)",
   goteShortName: "Hậu thủ (ngắn)",
+  scorekeeper: "記録係", // TODO: translate
   opusNo: "Số hiệu",
   opusName: "Tên tác phẩm",
   publishedBy: "Xuất bản bởi",

--- a/src/common/i18n/locales/zh_tw.ts
+++ b/src/common/i18n/locales/zh_tw.ts
@@ -385,6 +385,7 @@ export const zh_tw: Texts = {
   note: "備註",
   senteShortName: "先手省略名",
   goteShortName: "後手省略名",
+  scorekeeper: "記録係", // TODO: translate
   opusNo: "作品編號",
   opusName: "作品名",
   publishedBy: "發表於",

--- a/src/common/i18n/record.ts
+++ b/src/common/i18n/record.ts
@@ -47,6 +47,8 @@ export function getRecordMetadataName(key: RecordMetadataKey): string {
       return t.senteShortName;
     case RecordMetadataKey.WHITE_SHORT_NAME:
       return t.goteShortName;
+    case RecordMetadataKey.SCOREKEEPER:
+      return t.scorekeeper;
     case RecordMetadataKey.OPUS_NO:
       return t.opusNo;
     case RecordMetadataKey.OPUS_NAME:

--- a/src/common/i18n/text_template.ts
+++ b/src/common/i18n/text_template.ts
@@ -383,6 +383,7 @@ export type Texts = {
   note: string;
   senteShortName: string;
   goteShortName: string;
+  scorekeeper: string;
   opusNo: string;
   opusName: string;
   publishedBy: string;


### PR DESCRIPTION
# 説明 / Description

https://github.com/sunfish-shogi/tsshogi/issues/24

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [x] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added localization support for the term "Scorekeeper" in English, Japanese, Vietnamese, and Traditional Chinese, improving the user experience for multilingual users.
	- Enhanced functionality to handle scorekeeper metadata within the application.

- **Documentation**
	- Updated the `Texts` type to include a new property for scorekeeper, aiding in internationalization efforts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->