### PR TITLE
Fix command line tool

### DIFF
--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -62,6 +62,7 @@ import { useErrorStore } from "./error";
 import { useBusyState } from "./busy";
 import { Confirmation, useConfirmationStore } from "./confirm";
 import { LayoutProfile, LayoutProfileList } from "@/common/settings/layout";
+import { clearURLParams, loadRecordForWebApp, saveRecordForWebApp } from "./webapp";
 
 export type PVPreview = {
   position: ImmutablePosition;
@@ -121,7 +122,7 @@ function getMessageAttachmentsByGameResults(results: GameResults): Attachment[] 
 }
 
 class Store {
-  private recordManager = new RecordManager();
+  private recordManager = new RecordManager(loadRecordForWebApp());
   private _appState = AppState.NORMAL;
   private _customLayout: LayoutProfile | null = null;
   private _isAppSettingsDialogVisible = false;
@@ -147,19 +148,23 @@ class Store {
     this.recordManager
       .on("changePosition", () => {
         this.onChangePositionHandlers.forEach((handler) => handler());
+        saveRecordForWebApp(this.record);
+        this.updateResearchPosition();
       })
       .on("updateTree", () => {
         this.onUpdateRecordTreeHandlers.forEach((handler) => handler());
+        saveRecordForWebApp(this.record);
+        clearURLParams();
       })
       .on("updateCustomData", () => {
         this.onUpdateCustomDataHandlers.forEach((handler) => handler());
+        saveRecordForWebApp(this.record);
       })
       .on("backup", () => {
         return {
           returnCode: useAppSettings().returnCode,
         };
       });
-    this.onChangePositionHandlers.push(this.updateResearchPosition.bind(refs));
     this.gameManager
       .on("saveRecord", this.onSaveRecord.bind(refs))
       .on("gameEnd", this.onGameEnd.bind(refs))

--- a/src/renderer/store/webapp.ts
+++ b/src/renderer/store/webapp.ts
@@ -5,9 +5,9 @@ import { isMobileWebApp, isNative } from "@/renderer/ipc/api";
 const mobileRecordStorageKey = "mobile:record";
 const mobilePlyStorageKey = "mobile:ply";
 
-export function loadRecordForWebApp(): Record | null {
+export function loadRecordForWebApp(): Record | undefined {
   if (isNative()) {
-    return null;
+    return;
   }
 
   const urlParams = new URL(window.location.toString()).searchParams;
@@ -18,7 +18,7 @@ export function loadRecordForWebApp(): Record | null {
     const record = Record.newByUSEN(usen, branch, ply);
     if (record instanceof Error) {
       useErrorStore().add(`棋譜の読み込み中にエラーが発生しました。: ${record}`);
-      return null;
+      return;
     }
     const bname = urlParams.get("bname") || "";
     const wname = urlParams.get("wname") || "";
@@ -28,16 +28,16 @@ export function loadRecordForWebApp(): Record | null {
   }
 
   if (!isMobileWebApp()) {
-    return null;
+    return;
   }
 
   const data = localStorage.getItem(mobileRecordStorageKey);
   if (data === null) {
-    return null;
+    return;
   }
   const record = importKIF(data);
   if (record instanceof Error) {
-    return null;
+    return;
   }
   const ply = Number.parseInt(localStorage.getItem(mobilePlyStorageKey) || "0");
   record.goto(ply);

--- a/src/tests/background/version/check.spec.ts
+++ b/src/tests/background/version/check.spec.ts
@@ -104,6 +104,7 @@ describe("version", () => {
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     vi.clearAllMocks();
     vi.useRealTimers();
     fs.unlinkSync(statusFilePath);

--- a/src/tests/renderer/store/record.spec.ts
+++ b/src/tests/renderer/store/record.spec.ts
@@ -16,63 +16,11 @@ import { SCORE_MATE_INFINITE } from "@/common/game/usi";
 import { RecordManager, SearchInfoSenderType } from "@/renderer/store/record";
 
 describe("store/record", () => {
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
   it("new", () => {
     const recordManager = new RecordManager();
     expect(recordManager.unsaved).toBeFalsy();
     expect(recordManager.record.position.sfen).toBe(InitialPositionSFEN.STANDARD);
     expect(recordManager.record.moves).toHaveLength(1);
-  });
-
-  it("withUSENParam", () => {
-    vi.stubGlobal("window", {
-      location: {
-        toString: () =>
-          "http://localhost/?usen=~0.7ku2jm6y20e45t2.&branch=0&ply=2&bname=bbb&wname=www",
-      },
-    });
-    const recordManager = new RecordManager();
-    expect(recordManager.unsaved).toBeFalsy();
-    expect(recordManager.record.getUSI({ allMoves: true })).toBe(
-      "position startpos moves 7g7f 3c3d 2g2f 4a3b 2f2e",
-    );
-    expect(recordManager.record.moves).toHaveLength(6);
-    expect(recordManager.record.current.ply).toBe(2);
-  });
-
-  it("pcWeb/withoutLocalStorage", () => {
-    vi.stubGlobal("window", {
-      location: {
-        toString: () => "http://localhost/",
-      },
-      history: {
-        replaceState: vi.fn(),
-      },
-    });
-    const recordManager1 = new RecordManager();
-    recordManager1.importRecord("position startpos moves 5g5f 3c3d 2h5h 7a6b");
-    const recordManager2 = new RecordManager();
-    expect(recordManager2.record.getUSI({ allMoves: true })).toBe("position startpos");
-  });
-
-  it("mobileWeb/localStorage", () => {
-    vi.stubGlobal("window", {
-      location: {
-        toString: () => "http://localhost/?mobile",
-      },
-      history: {
-        replaceState: vi.fn(),
-      },
-    });
-    const recordManager1 = new RecordManager();
-    recordManager1.importRecord("position startpos moves 5g5f 3c3d 2h5h 7a6b");
-    const recordManager2 = new RecordManager();
-    expect(recordManager2.record.getUSI({ allMoves: true })).toBe(
-      "position startpos moves 5g5f 3c3d 2h5h 7a6b",
-    );
   });
 
   it("reset", () => {

--- a/src/tests/renderer/store/webapp.spec.ts
+++ b/src/tests/renderer/store/webapp.spec.ts
@@ -1,0 +1,54 @@
+import { createStore } from "@/renderer/store";
+import { Move } from "tsshogi";
+
+describe("store/webapp", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("withUSENParam", () => {
+    vi.stubGlobal("window", {
+      location: {
+        toString: () =>
+          "http://localhost/?usen=~0.7ku2jm6y20e45t2.&branch=0&ply=2&bname=bbb&wname=www",
+      },
+    });
+    const store = createStore();
+    expect(store.isRecordFileUnsaved).toBeFalsy();
+    expect(store.record.getUSI({ allMoves: true })).toBe(
+      "position startpos moves 7g7f 3c3d 2g2f 4a3b 2f2e",
+    );
+    expect(store.record.moves).toHaveLength(6);
+    expect(store.record.current.ply).toBe(2);
+  });
+
+  it("pcWeb/withoutLocalStorage", () => {
+    vi.stubGlobal("window", {
+      location: {
+        toString: () => "http://localhost/",
+      },
+      history: {
+        replaceState: vi.fn(),
+      },
+    });
+    const store = createStore();
+    store.doMove(store.record.position.createMoveByUSI("5g5f") as Move);
+    const store2 = createStore();
+    expect(store2.record.getUSI({ allMoves: true })).toBe("position startpos");
+  });
+
+  it("mobileWeb/localStorage", () => {
+    vi.stubGlobal("window", {
+      location: {
+        toString: () => "http://localhost/?mobile",
+      },
+      history: {
+        replaceState: vi.fn(),
+      },
+    });
+    const store = createStore();
+    store.doMove(store.record.position.createMoveByUSI("5g5f") as Move);
+    const store2 = createStore();
+    expect(store2.record.getUSI({ allMoves: true })).toBe("position startpos moves 5g5f");
+  });
+});


### PR DESCRIPTION
# 説明 / Description

#943 で `@/renderer/store/record.ts` から `@/renderer/store/webapp.ts` への参照をしてしまったことで、コマンドラインツールが動かなくなっていた。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced record management for web applications, improving the loading and saving processes.
	- Introduced new mechanisms for handling URL parameters and record updates.

- **Bug Fixes**
	- Improved handling of return values in the `loadRecordForWebApp` function to enhance type safety.

- **Tests**
	- Added a new test suite for the `createStore` function, validating its behavior under various conditions.
	- Improved test cleanup processes to enhance reliability and isolation of tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->