### PR TITLE
盤面に表示するAI候補手を絞る条件を修正

### DIFF
--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -449,11 +449,19 @@ class Store {
         if (!iteration.pv?.length) {
           continue;
         }
-        if (iteration.score) {
-          if (iteration.score < maxScore - maxScoreDiff) {
+        const score =
+          iteration.score !== undefined
+            ? iteration.score
+            : iteration.scoreMate
+              ? iteration.scoreMate > 0
+                ? 1e8 - iteration.scoreMate
+                : -1e8 - iteration.scoreMate
+              : undefined;
+        if (score !== undefined) {
+          if (score < maxScore - maxScoreDiff) {
             continue;
-          } else if (iteration.score > maxScore) {
-            maxScore = iteration.score;
+          } else if (score > maxScore) {
+            maxScore = score;
           }
         }
         const usi = iteration.pv[0];

--- a/src/tests/renderer/store/index.spec.ts
+++ b/src/tests/renderer/store/index.spec.ts
@@ -176,7 +176,6 @@ describe("store/index", () => {
 
   it("candidates", async () => {
     vi.useFakeTimers();
-    await useAppSettings().updateAppSettings({ maxArrowsPerEngine: 3 });
     const usi = "position startpos moves 7g7f";
     const store = createStore();
     store.pasteRecord(usi);
@@ -189,11 +188,16 @@ describe("store/index", () => {
     });
     store.updateUSIInfo(101, usi, "Engine A", {
       multipv: 2,
+      scoreCP: 0,
+      pv: ["4a3b", "2g2f"],
+    });
+    store.updateUSIInfo(101, usi, "Engine A", {
+      multipv: 3,
       scoreCP: -5,
       pv: ["3c3d", "2g2f"],
     });
     store.updateUSIInfo(101, usi, "Engine A", {
-      multipv: 3,
+      multipv: 4,
       scoreCP: -21,
       pv: ["5c5d", "2g2f"],
     });
@@ -201,11 +205,35 @@ describe("store/index", () => {
       scoreCP: -5,
       pv: ["9c9d", "9g9f"],
     });
+    store.updateUSIInfo(103, usi, "Engine C", {
+      multipv: 1,
+      scoreMate: 3,
+      pv: ["3c3d", "5g5f"],
+    });
+    store.updateUSIInfo(103, usi, "Engine C", {
+      multipv: 2,
+      scoreCP: 150,
+      pv: ["1c1d", "5g5f"],
+    });
+    store.updateUSIInfo(103, usi, "Engine C", {
+      multipv: 3,
+      scoreMate: -5,
+      pv: ["7c7d", "5g5f"],
+    });
     vi.runOnlyPendingTimers();
-    expect(store.candidates).toHaveLength(3);
+
+    await useAppSettings().updateAppSettings({ maxArrowsPerEngine: 3 });
+    expect(store.candidates).toHaveLength(4);
+    expect(store.candidates[0].usi).toBe("8c8d");
+    expect(store.candidates[1].usi).toBe("4a3b");
+    expect(store.candidates[2].usi).toBe("3c3d");
+    expect(store.candidates[3].usi).toBe("9c9d");
 
     await useAppSettings().updateAppSettings({ maxArrowsPerEngine: 1 });
-    expect(store.candidates).toHaveLength(2);
+    expect(store.candidates).toHaveLength(3);
+    expect(store.candidates[0].usi).toBe("8c8d");
+    expect(store.candidates[1].usi).toBe("9c9d");
+    expect(store.candidates[2].usi).toBe("3c3d");
 
     await useAppSettings().updateAppSettings({ maxArrowsPerEngine: 0 });
     expect(store.candidates).toHaveLength(0);


### PR DESCRIPTION
# 説明 / Description

#961

最善手から評価値の差が 100 以内であることを条件として、候補手を盤面に表示していた。
しかし、詰みが含まれる場合に意図通り判定できていなかったので修正する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [x] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced scoring mechanism for improved flexibility in score evaluation.
	- Updated candidate management logic to accommodate new engine data.

- **Bug Fixes**
	- Adjusted handling of candidates based on `maxArrowsPerEngine` settings to ensure accurate processing.

- **Tests**
	- Expanded test coverage for candidate management to validate new scoring and engine-related changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->