### PR TITLE
エクスプローラーを開く前にディレクトリが存在するかチェックする改善

### DIFF
--- a/src/background/file/history.ts
+++ b/src/background/file/history.ts
@@ -9,7 +9,7 @@ import {
 } from "@/common/file/history";
 import { getAppLogger } from "@/background/log";
 import AsyncLock from "async-lock";
-import { requireElectron } from "@/background/helpers/portability";
+import { openPath } from "@/background/helpers/electron";
 
 const historyMaxLength = 20;
 
@@ -17,8 +17,8 @@ const userDir = getAppPath("userData");
 const historyPath = path.join(userDir, "record_file_history.json");
 const backupDir = path.join(userDir, "backup/kifu");
 
-export function openBackupDirectory(): void {
-  requireElectron().shell.openPath(backupDir);
+export function openBackupDirectory(): Promise<void> {
+  return openPath(backupDir);
 }
 
 const lock = new AsyncLock();

--- a/src/background/helpers/electron.ts
+++ b/src/background/helpers/electron.ts
@@ -1,12 +1,20 @@
-import { getAppLogger } from "@/background/log";
 import { requireElectron } from "@/background/helpers/portability";
+import { exists } from "./file";
+import { t } from "@/common/i18n";
 
 export function getAppVersion(): string {
   return requireElectron().app.getVersion();
 }
 
+export async function openPath(path: string) {
+  // 存在しないパスを開こうとした場合の振る舞いがプラットフォームによって異なるため、事前に存在チェックを行う。
+  if (!(await exists(path))) {
+    throw new Error(t.failedToOpenDirectory(path));
+  }
+  requireElectron().shell.openPath(path);
+}
+
 export function showNotification(title: string, body: string) {
-  getAppLogger().debug(`show notification: ${title}: ${body}`);
   new (requireElectron().Notification)({
     title,
     body,

--- a/src/background/image/cache.ts
+++ b/src/background/image/cache.ts
@@ -1,10 +1,10 @@
 import path from "node:path";
 import { getAppPath, getPortableExeDir } from "@/background/proc/env";
-import { requireElectron } from "@/background/helpers/portability";
+import { openPath } from "@/background/helpers/electron";
 
 const userDataRoot = getPortableExeDir() || getAppPath("userData");
 export const imageCacheDir = path.join(userDataRoot, "image_cache");
 
-export function openCacheDirectory() {
-  requireElectron().shell.openPath(imageCacheDir);
+export function openCacheDirectory(): Promise<void> {
+  return openPath(imageCacheDir);
 }

--- a/src/background/log.ts
+++ b/src/background/log.ts
@@ -4,12 +4,12 @@ import * as log4js from "log4js";
 import { getDateTimeString } from "@/common/helpers/datetime";
 import { getAppPath, isTest } from "./proc/env";
 import { LogLevel, LogType } from "@/common/log";
-import { requireElectron } from "./helpers/portability";
+import { openPath } from "./helpers/electron";
 
 const rootDir = getAppPath("logs");
 
-export function openLogsDirectory(): void {
-  requireElectron().shell.openPath(rootDir);
+export function openLogsDirectory(): Promise<void> {
+  return openPath(rootDir);
 }
 
 const datetime = getDateTimeString().replaceAll(" ", "_").replaceAll("/", "").replaceAll(":", "");
@@ -108,8 +108,8 @@ export function shutdownLoggers(): void {
   });
 }
 
-export function openLogFile(logType: LogType): void {
-  requireElectron().shell.openPath(getFilePath(logType));
+export function openLogFile(logType: LogType): Promise<void> {
+  return openPath(getFilePath(logType));
 }
 
 export function getTailCommand(logType: LogType): string {

--- a/src/background/proc/env.ts
+++ b/src/background/proc/env.ts
@@ -64,3 +64,12 @@ export function getAppPath(name: "userData" | "logs" | "exe" | "documents" | "pi
 export function getPreloadPath() {
   return isProduction() ? "./preload.js" : "../../../packed/preload.js";
 }
+
+export const electronLicensePath = path.join(
+  path.dirname(getAppPath("exe")),
+  "LICENSE.electron.txt",
+);
+export const chromiumLicensePath = path.join(
+  path.dirname(getAppPath("exe")),
+  "LICENSES.chromium.html",
+);

--- a/src/background/settings.ts
+++ b/src/background/settings.ts
@@ -39,20 +39,20 @@ import {
   normalizeBatchConversionSettings as normalizeBatchConversionSettings,
 } from "@/common/settings/conversion";
 import { exists } from "./helpers/file";
-import { requireElectron } from "./helpers/portability";
 import { emptyLayoutProfileList, LayoutProfileList } from "@/common/settings/layout";
+import { openPath } from "./helpers/electron";
 
 const userDir = getAppPath("userData");
 const rootDir = getPortableExeDir() || userDir;
 const docDir = path.join(getAppPath("documents"), "ShogiHome");
 
-export function openSettingsDirectory(): void {
-  requireElectron().shell.openPath(rootDir);
+export function openSettingsDirectory(): Promise<void> {
+  return openPath(rootDir);
 }
 
 export async function openAutoSaveDirectory(): Promise<void> {
   const appSettings = await loadAppSettings();
-  requireElectron().shell.openPath(appSettings.autoSaveDirectory || docDir);
+  await openPath(appSettings.autoSaveDirectory || docDir);
 }
 
 const windowSettingsPath = path.join(userDir, "window.json");

--- a/src/background/version/check.ts
+++ b/src/background/version/check.ts
@@ -78,6 +78,7 @@ function suggestUpdate(releases: Releases, last: VersionStatus) {
   const stableUpdated = !knownStable || semver.gt(stable, knownStable);
   const stableNotInstalled = semver.gt(stable, current);
   if (stablePreferred && stableUpdated && stableNotInstalled) {
+    getAppLogger().info(`new stable version released: ${stable}`);
     showNotification(t.shogiHome, t.stableVersionReleased("v" + stable));
     return;
   }
@@ -86,6 +87,7 @@ function suggestUpdate(releases: Releases, last: VersionStatus) {
   const latestUpdated = !knownLatest || semver.gt(latest, knownLatest);
   const latestNotInstalled = semver.gt(latest, current);
   if (latestPreferred && latestUpdated && latestNotInstalled) {
+    getAppLogger().info(`new latest version released: ${latest}`);
     showNotification(t.shogiHome, t.latestVersionReleased("v" + latest));
     return;
   }

--- a/src/background/window/ipc.ts
+++ b/src/background/window/ipc.ts
@@ -92,6 +92,7 @@ import { PromptTarget } from "@/common/advanced/prompt";
 import { Command, CommandType } from "@/common/advanced/command";
 import { fetch } from "@/background/helpers/http";
 import * as uri from "@/common/uri";
+import { openPath } from "@/background/helpers/electron";
 
 const isWindows = process.platform === "win32";
 
@@ -146,9 +147,9 @@ ipcMain.on(Background.OPEN_EXPLORER, async (event, targetPath: string) => {
     const fullPath = resolveEnginePath(targetPath);
     const stats = await fs.stat(fullPath);
     if (stats.isDirectory()) {
-      shell.openPath(fullPath);
+      await openPath(fullPath);
     } else {
-      shell.openPath(path.dirname(fullPath));
+      await openPath(path.dirname(fullPath));
     }
   } catch {
     sendError(new Error(t.failedToOpenDirectory(targetPath)));

--- a/src/background/window/menu.ts
+++ b/src/background/window/menu.ts
@@ -21,7 +21,7 @@ import { AppState, ResearchState } from "@/common/control/state";
 import { openHowToUse, openLatestReleasePage, openStableReleasePage, openWebsite } from "./help";
 import { t } from "@/common/i18n";
 import { InitialPositionSFEN } from "tsshogi";
-import { getAppPath } from "@/background/proc/env";
+import { chromiumLicensePath, electronLicensePath, getAppPath } from "@/background/proc/env";
 import { openBackupDirectory } from "@/background/file/history";
 import { openCacheDirectory } from "@/background/image/cache";
 import { refreshCustomPieceImages, sendTestNotification } from "./debug";
@@ -29,6 +29,7 @@ import { LogType } from "@/common/log";
 import { createLayoutManagerWindow } from "./layout";
 import { licenseURL, thirdPartyLicenseURL } from "@/common/links/github";
 import { materialIconsGuideURL } from "@/common/links/google";
+import { openPath } from "@/background/helpers/electron";
 
 const isWin = process.platform === "win32";
 const isMac = process.platform === "darwin";
@@ -96,7 +97,9 @@ function createMenuTemplate(window: BrowserWindow) {
         { type: "separator" },
         {
           label: t.openAutoSaveDirectory,
-          click: openAutoSaveDirectory,
+          click: () => {
+            openAutoSaveDirectory().catch(sendError);
+          },
         },
         { type: "separator" },
         isMac ? { role: "close", label: t.close } : { role: "quit", label: t.quit },
@@ -371,28 +374,38 @@ function createMenuTemplate(window: BrowserWindow) {
         {
           label: t.app,
           click: () => {
-            shell.openPath(path.dirname(getAppPath("exe")));
+            openPath(path.dirname(getAppPath("exe"))).catch(sendError);
           },
         },
         {
           label: t.settings,
-          click: openSettingsDirectory,
+          click: () => {
+            openSettingsDirectory().catch(sendError);
+          },
         },
         {
           label: t.log,
-          click: openLogsDirectory,
+          click: () => {
+            openLogsDirectory().catch(sendError);
+          },
         },
         {
           label: t.cache,
-          click: openCacheDirectory,
+          click: () => {
+            openCacheDirectory().catch(sendError);
+          },
         },
         {
           label: t.backup,
-          click: openBackupDirectory,
+          click: () => {
+            openBackupDirectory().catch(sendError);
+          },
         },
         {
           label: t.autoSaving,
-          click: openAutoSaveDirectory,
+          click: () => {
+            openAutoSaveDirectory().catch(sendError);
+          },
         },
       ],
     },
@@ -412,19 +425,19 @@ function createMenuTemplate(window: BrowserWindow) {
             {
               label: t.openAppLog,
               click: () => {
-                openLogFile(LogType.APP);
+                openLogFile(LogType.APP).catch(sendError);
               },
             },
             {
               label: t.openUSILog,
               click: () => {
-                openLogFile(LogType.USI);
+                openLogFile(LogType.USI).catch(sendError);
               },
             },
             {
               label: t.openCSALog,
               click: () => {
-                openLogFile(LogType.CSA);
+                openLogFile(LogType.CSA).catch(sendError);
               },
             },
             {
@@ -540,15 +553,13 @@ function createMenuTemplate(window: BrowserWindow) {
             {
               label: "Electron",
               click: () => {
-                shell.openPath(path.join(path.dirname(getAppPath("exe")), "LICENSE.electron.txt"));
+                openPath(electronLicensePath).catch(sendError);
               },
             },
             {
               label: "Chromium",
               click: () => {
-                shell.openPath(
-                  path.join(path.dirname(getAppPath("exe")), "LICENSES.chromium.html"),
-                );
+                openPath(chromiumLicensePath).catch(sendError);
               },
             },
           ],


### PR DESCRIPTION
# 説明 / Description

#977 

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced asynchronous path opening functionality for various directories (settings, logs, cache, and backups).
	- Added constants for Electron and Chromium license paths.

- **Bug Fixes**
	- Enhanced error handling for menu item actions to manage promise rejections.

- **Documentation**
	- Improved logging for version updates to inform users about new releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->