### PR TITLE
深さの表示に関する軽微な修正

### DIFF
--- a/src/renderer/view/tab/EngineAnalyticsElement.vue
+++ b/src/renderer/view/tab/EngineAnalyticsElement.vue
@@ -67,7 +67,11 @@
                 {{ iteration.multiPV || "" }}
               </td>
               <td v-if="showDepthColumn" class="depth">
-                {{ iteration.depth }}{{ iteration.selectiveDepth && iteration.depth ? "/" : ""
+                {{ iteration.depth
+                }}{{
+                  iteration.selectiveDepth !== undefined && iteration.depth !== undefined
+                    ? "/"
+                    : ""
                 }}{{ iteration.selectiveDepth }}
               </td>
               <td v-if="showNodesColumn" class="nodes">


### PR DESCRIPTION
# 説明 / Description

seldepth が 0 の場合にスラッシュが表示されていなかったのを修正する。

# チェックリスト / Checklist

- MUST
  - [x] `npm test` passed
  - [x] `npm run lint` was applied without warnings
  - [x] changes of `/docs/webapp` not included (except release branch)
  - [x] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced display of depth information in the analytics table, conditionally including `selectiveDepth` for improved clarity.

- **Bug Fixes**
	- No bug fixes were implemented in this release. 

- **Documentation**
	- No updates to documentation were made. 

- **Style**
	- No changes to styling were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->