### PR TITLE
Fix to use links of release.json instead of hard coding

### DIFF
--- a/src/background/window/help.ts
+++ b/src/background/window/help.ts
@@ -1,11 +1,6 @@
 import { shell } from "electron";
 import { readStatus } from "@/background/version/check";
-import {
-  howToUseWikiPageURL,
-  latestReleaseURL,
-  stableReleaseURL,
-  websiteURL,
-} from "@/common/links/github";
+import { howToUseWikiPageURL, websiteURL } from "@/common/links/github";
 
 export function openWebsite(): void {
   shell.openExternal(websiteURL);
@@ -15,8 +10,12 @@ export function openHowToUse(): void {
   shell.openExternal(howToUseWikiPageURL);
 }
 
-export function openLatestReleasePage(): void {
-  shell.openExternal(latestReleaseURL);
+export async function openLatestReleasePage() {
+  const status = await readStatus();
+  if (!status.knownReleases) {
+    throw new Error("No known releases");
+  }
+  shell.openExternal(status.knownReleases.latest.link);
 }
 
 export async function openStableReleasePage() {
@@ -24,6 +23,5 @@ export async function openStableReleasePage() {
   if (!status.knownReleases) {
     throw new Error("No known releases");
   }
-  const tag = status.knownReleases.stable.tag;
-  shell.openExternal(stableReleaseURL(tag));
+  shell.openExternal(status.knownReleases.stable.link);
 }

--- a/src/background/window/menu.ts
+++ b/src/background/window/menu.ts
@@ -521,7 +521,9 @@ function createMenuTemplate(window: BrowserWindow) {
         },
         {
           label: t.openLatestReleasePage,
-          click: openLatestReleasePage,
+          click: () => {
+            openLatestReleasePage().catch(sendError);
+          },
         },
         {
           label: t.openStableReleasePage,

--- a/src/common/links/github.ts
+++ b/src/common/links/github.ts
@@ -20,10 +20,6 @@ export const wikiPageBaseURL = `https://${ghDomain}/${ghAccount}/${ghRepository}
 export const howToUseWikiPageURL = `${wikiPageBaseURL}${howToUseTitle}`;
 export const fileNameTemplateWikiPageURL = `${wikiPageBaseURL}${fileNameTemplateTitle}`;
 export const maxPVLengthSettingWikiPageURL = `${wikiPageBaseURL}${maxPVLengthTitle}`;
-export const latestReleaseURL = `https://${ghDomain}/${ghAccount}/${ghRepository}/releases/latest`;
-export function stableReleaseURL(tag: string) {
-  return `https://${ghDomain}/${ghAccount}/${ghRepository}/releases/tag/${tag}`;
-}
 export const licenseURL = `https://${ghDomain}/${ghAccount}/${ghRepository}/blob/main/LICENSE`;
 
 const webAppBaseURL = `https://${ghioDomain}/${ghRepository}/webapp/index.html`;


### PR DESCRIPTION
# 説明 / Description

#986 

# チェックリスト / Checklist

- MUST
  - [ ] `npm test` passed
  - [ ] `npm run lint` was applied without warnings
  - [ ] changes of `/docs/webapp` not included (except release branch)
  - [ ] `console.log` not included (except script file)
- MUST for Outside Contributor
  - [ ] understand [プロジェクトへの関わり方について](https://github.com/sunfish-shogi/electron-shogi/wiki/%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%81%B8%E3%81%AE%E9%96%A2%E3%82%8F%E3%82%8A%E6%96%B9%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- RECOMMENDED (it depends on what you change)
  - [ ] unit test added/updated
  - [ ] i18n
